### PR TITLE
[FEAT] Genre UICollectionView 구현

### DIFF
--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		97C17C86288738A300A510CA /* MainViewController+GenreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C17C85288738A300A510CA /* MainViewController+GenreCell.swift */; };
 		A38A4C57287E97B900614E94 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A4C56287E97B900614E94 /* SearchViewController.swift */; };
 		A38A4C59287E97CF00614E94 /* SearchDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A4C58287E97CF00614E94 /* SearchDetailViewController.swift */; };
 		C039DCBA287D940F0007951D /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCB9287D940F0007951D /* MainTabController.swift */; };
@@ -44,6 +45,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		97C17C85288738A300A510CA /* MainViewController+GenreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+GenreCell.swift"; sourceTree = "<group>"; };
 		A38A4C56287E97B900614E94 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		A38A4C58287E97CF00614E94 /* SearchDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDetailViewController.swift; sourceTree = "<group>"; };
 		C039DCB9287D940F0007951D /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				C05BF1DC287BC60600C95E1B /* MainViewController.swift */,
 				A38A4C56287E97B900614E94 /* SearchViewController.swift */,
 				A38A4C58287E97CF00614E94 /* SearchDetailViewController.swift */,
+				97C17C85288738A300A510CA /* MainViewController+GenreCell.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -319,6 +322,7 @@
 				C05BF1F7287BC7EF00C95E1B /* String.swift in Sources */,
 				C05BF1FF287BC90900C95E1B /* Device.swift in Sources */,
 				C05BF1C9287BC33100C95E1B /* AppDelegate.swift in Sources */,
+				97C17C86288738A300A510CA /* MainViewController+GenreCell.swift in Sources */,
 				C05BF203287BC99A00C95E1B /* BaseViewController.swift in Sources */,
 				C05BF1CB287BC33100C95E1B /* SceneDelegate.swift in Sources */,
 				C05BF209287BCAD900C95E1B /* Dancer.swift in Sources */,

--- a/Hypeclass/Source/Main/MainViewController+GenreCell.swift
+++ b/Hypeclass/Source/Main/MainViewController+GenreCell.swift
@@ -1,0 +1,66 @@
+//
+//  MainViewController+GenreCell.swift
+//  Hypeclass
+//
+//  Created by apple developer academy on 2022/07/18.
+//
+
+import UIKit
+
+class MainViewControllerGenreCell: UICollectionViewCell {
+
+    static let id = "MyCell"
+      
+    // MARK: UIImageView로 수정
+    private var imageView: UIStackView = {
+        let view = UIStackView()
+        view.backgroundColor = .gray
+        view.axis = .vertical
+        view.alignment = .center
+        view.layer.cornerRadius = 50
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let genreLabel: UILabel = {
+        let label = UILabel()
+        label.text = "스트릿 댄스"
+        label.font = UIFont.systemFont(ofSize: 12, weight: .bold)
+        label.numberOfLines = 2
+//        label.adjustsFontSizeToFitWidth = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+      
+      // MARK: Initializer
+      @available(*, unavailable)
+      required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+      }
+      
+      override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(imageView)
+        imageView.addArrangedSubview(genreLabel)
+          
+        NSLayoutConstraint.activate([
+          imageView.leftAnchor.constraint(equalTo: self.contentView.leftAnchor),
+          imageView.rightAnchor.constraint(equalTo: self.contentView.rightAnchor),
+          imageView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+          imageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+        ])
+      }
+      
+      override func prepareForReuse() {
+        super.prepareForReuse()
+        
+         self.prepare(image: nil)
+      }
+      
+    // MARK: UIImageView로 수정
+    func prepare(image: UIStackView?) {
+        self.imageView = image ?? UIStackView(frame: .zero)
+    }
+}
+

--- a/Hypeclass/Source/Main/MainViewController.swift
+++ b/Hypeclass/Source/Main/MainViewController.swift
@@ -10,72 +10,134 @@ import UIKit
 class MainViewController: BaseViewController {
     // MARK: - Properties
     
-    let titleLabel: UILabel = {
+    private let headerView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.spacing = 20
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let headerTitle: UILabel = {
         let label = UILabel()
         label.text = "댄서들의 클래스를 확인해보세요"
         label.font = UIFont.systemFont(ofSize: 22, weight: .bold)
         label.adjustsFontSizeToFitWidth = true
-        
-        // MARK: - TODO: func textRect(라벨 박스 크기 확인)
-        
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
-    let searchButton: UIButton = {
-        var config = UIButton.Configuration.gray()
-        config.buttonSize = .large
-        config.titleAlignment = .leading
-        config.title = "찾고자 하는 댄서나 장르를 검색해보세요"
-        config.background = .listSidebarCell()
-        
-        config.image = UIImage(systemName: "magnifyingglass")
-        config.imagePadding = 4
-        config.imagePlacement = .leading
-        config.baseForegroundColor = UIColor(hex: 0x7A7A7A)
-        config.baseBackgroundColor = UIColor(hex: 0x2D2C38)
-        let button = UIButton (
-            configuration: config, primaryAction: UIAction(handler: { _ in
-            print("MainViewController -> SearchViewController")
-                
-            // MARK: TO_DO: searchView 연결
-                
+    private let searchButton: UIButton = {
+       var config = UIButton.Configuration.gray()
+       config.buttonSize = .large
+       config.titleAlignment = .leading
+       config.title = "댄서 또는 장르를 검색해보세요"
+       config.background = .listSidebarCell()
+       config.image = UIImage(systemName: "magnifyingglass")
+       config.imagePadding = 4
+       config.imagePlacement = .leading
+       
+       config.baseForegroundColor = UIColor(hex: 0x7A7A7A)
+       config.baseBackgroundColor = UIColor(hex: 0x2D2C38)
+       
+       let button = UIButton (
+           configuration: config, primaryAction: UIAction(handler: { _ in
+           print("MainViewController -> SearchViewController")
+           // TODO: searchView 연결
 //            let searchViewController = SearchViewController()
 //            UINavigationController?.pushViewController(searchViewController, animated: true)
-            })
-        )
-        button.contentHorizontalAlignment = .leading
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
+           })
+       )
+       button.contentHorizontalAlignment = .leading
+       button.translatesAutoresizingMaskIntoConstraints = false
+       return button
+   }()
     
+    private let genreView: UIStackView = {
+            let view = UIStackView()
+            view.axis = .vertical
+            view.spacing = 10
+            view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        }()
+        
+        private let genreTitle: UILabel = {
+            let label = UILabel()
+            label.text = "이 장르에 도전해보는건 어때요?"
+            label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+            label.adjustsFontSizeToFitWidth = true
+            
+            //MARK: - TODO: func textRect(라벨 박스 크기 확인)
+            label.translatesAutoresizingMaskIntoConstraints = false
+            return label
+        }()
+        
+        private let genreFlowLayout: UICollectionViewFlowLayout = {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            layout.minimumLineSpacing = 12.0
+            layout.minimumInteritemSpacing = 12.0
+            layout.itemSize = CGSize(width: 100, height: 100)
+            return layout
+          }()
+        
+        private lazy var genreCollectionView: UICollectionView = {
+            let view = UICollectionView(frame: .zero, collectionViewLayout: self.genreFlowLayout)
+            view.isScrollEnabled = true
+            view.showsHorizontalScrollIndicator = false
+            view.showsVerticalScrollIndicator = true
+            view.contentInset = .zero
+            view.backgroundColor = .clear
+            view.clipsToBounds = true
+            view.register(MainViewControllerGenreCell.self, forCellWithReuseIdentifier: "MyCell")
+            view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        }()
+
     // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureUI()
         
-        view.addSubview(titleLabel)
-        view.addSubview(searchButton)
-        // MARK: - AutoLayout
-        
-        titleConstraint()
-        searchButtonConstraint()
+        genreCollectionView.dataSource = self
     }
     // MARK: - Selectors
     // MARK: - Helpers
-    
-    private func titleConstraint() {
+    private func configureUI() {
+        view.addSubview(headerView)
+        headerView.addArrangedSubview(headerTitle)
+        headerView.addArrangedSubview(searchButton)
+        
+        view.addSubview(genreView)
+        genreView.addArrangedSubview(genreTitle)
+        genreView.addArrangedSubview(genreCollectionView)
+        
         let safeArea = self.view.safeAreaLayoutGuide
-        self.titleLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 60).isActive = true
-        self.titleLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 25).isActive = true
+        NSLayoutConstraint.activate([
+            headerView.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 20),
+            headerView.leftAnchor.constraint(equalTo: safeArea.leftAnchor, constant: 25),
+            headerView.rightAnchor.constraint(equalTo: safeArea.rightAnchor, constant: -25),
+       ])
+        NSLayoutConstraint.activate([
+            genreView.leftAnchor.constraint(equalTo: safeArea.leftAnchor, constant: 25),
+            genreView.rightAnchor.constraint(equalTo: safeArea.rightAnchor),
+            genreView.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 180),
+            genreView.heightAnchor.constraint(equalToConstant: 150),
+       ])
     }
+}
+
+extension MainViewController: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return 10
+  }
     
-    private func searchButtonConstraint() {
-        let safeArea = self.view.safeAreaLayoutGuide
-        self.searchButton.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 120).isActive = true
-        self.searchButton.leftAnchor.constraint(equalTo: safeArea.leftAnchor, constant: 25).isActive = true
-        self.searchButton.rightAnchor.constraint(equalTo: safeArea.rightAnchor, constant: -25).isActive = true
-    }
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainViewControllerGenreCell.id, for: indexPath) as! MainViewControllerGenreCell
+        cell.prepare(image: UIStackView(frame: .zero))
+       return cell
+  }
 }
 
 // MARK: - Preview


### PR DESCRIPTION
## 개요
- #21 
- MainViewController 내부에 Genre StackView 생성 및 Genre Cell을 생성하여 Layout을 구성했습니다.

## 작업내용
- GenreCell 분리 및 Genre CollectionView 생성
- NSLayoutConstraint로 오토레이아웃 일괄 리팩토링
- configureUI 헬퍼 함수 분리
- StackView(headerView와 genreView) 리팩토링

## 고민사항
- indexPath로 리팩토링 시 MockData 필요
- UIColor Extension으로 리팩토링
- Max 기기에 레이아웃 확인 (itemSize)

## 이미지(UI 관련작업시)
<img width="1339" alt="스크린샷 2022-07-20 오후 2 58 38" src="https://user-images.githubusercontent.com/61782746/179909644-025fdc32-5944-4ffc-a505-13b792d205af.png">

