### PR TITLE
[FEAT] Firebase 전화번호 인증 로직, 회원가입 뷰 구현

### DIFF
--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		C0C444FC2894495D00036ADE /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FB2894495D00036ADE /* AuthViewController.swift */; };
 		C0C444FE28944DE200036ADE /* ContainerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FD28944DE200036ADE /* ContainerTextField.swift */; };
 		C0C445002894EE1300036ADE /* AuthPhoneNumberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FF2894EE1200036ADE /* AuthPhoneNumberViewController.swift */; };
+		C0C445022894F0DF00036ADE /* AuthVerificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C445012894F0DF00036ADE /* AuthVerificationController.swift */; };
 		C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */; };
 		C0C7B28928944395003FA2C2 /* CTAButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28828944395003FA2C2 /* CTAButton.swift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
@@ -133,6 +134,7 @@
 		C0C444FB2894495D00036ADE /* AuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
 		C0C444FD28944DE200036ADE /* ContainerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTextField.swift; sourceTree = "<group>"; };
 		C0C444FF2894EE1200036ADE /* AuthPhoneNumberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPhoneNumberViewController.swift; sourceTree = "<group>"; };
+		C0C445012894F0DF00036ADE /* AuthVerificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthVerificationController.swift; sourceTree = "<group>"; };
 		C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardViewController.swift; sourceTree = "<group>"; };
 		C0C7B28828944395003FA2C2 /* CTAButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTAButton.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
@@ -362,6 +364,7 @@
 				C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */,
 				C0C444FB2894495D00036ADE /* AuthViewController.swift */,
 				C0C444FF2894EE1200036ADE /* AuthPhoneNumberViewController.swift */,
+				C0C445012894F0DF00036ADE /* AuthVerificationController.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -475,6 +478,7 @@
 				C039DCBE287D944C0007951D /* ScheduleViewController.swift in Sources */,
 				C7CE67D3288FD2EA00C8F137 /* DancerManager.swift in Sources */,
 				C05BF1F3287BC7EF00C95E1B /* UIView.swift in Sources */,
+				C0C445022894F0DF00036ADE /* AuthVerificationController.swift in Sources */,
 				C05BF1FD287BC88400C95E1B /* IndicatorView.swift in Sources */,
 				C05BF1F4287BC7EF00C95E1B /* UIFont.swift in Sources */,
 				A38A4C57287E97B900614E94 /* SearchViewController.swift in Sources */,

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */; };
 		C0C444FC2894495D00036ADE /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FB2894495D00036ADE /* AuthViewController.swift */; };
 		C0C444FE28944DE200036ADE /* ContainerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FD28944DE200036ADE /* ContainerTextField.swift */; };
+		C0C445002894EE1300036ADE /* AuthPhoneNumberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FF2894EE1200036ADE /* AuthPhoneNumberViewController.swift */; };
 		C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */; };
 		C0C7B28928944395003FA2C2 /* CTAButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28828944395003FA2C2 /* CTAButton.swift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
@@ -131,6 +132,7 @@
 		C08A10B12883BCC1009A38E7 /* MockDataSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataSet.swift; sourceTree = "<group>"; };
 		C0C444FB2894495D00036ADE /* AuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
 		C0C444FD28944DE200036ADE /* ContainerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTextField.swift; sourceTree = "<group>"; };
+		C0C444FF2894EE1200036ADE /* AuthPhoneNumberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPhoneNumberViewController.swift; sourceTree = "<group>"; };
 		C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardViewController.swift; sourceTree = "<group>"; };
 		C0C7B28828944395003FA2C2 /* CTAButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTAButton.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 			children = (
 				C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */,
 				C0C444FB2894495D00036ADE /* AuthViewController.swift */,
+				C0C444FF2894EE1200036ADE /* AuthPhoneNumberViewController.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -487,6 +490,7 @@
 				C05BF1F2287BC7EF00C95E1B /* UITextField.swift in Sources */,
 				C7CE67D7288FD30900C8F137 /* StudioManager.swift in Sources */,
 				C07E5C91287E707200BDA46D /* Genre.swift in Sources */,
+				C0C445002894EE1300036ADE /* AuthPhoneNumberViewController.swift in Sources */,
 				C05BF1F8287BC7EF00C95E1B /* UIImage.swift in Sources */,
 				C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */,
 				C0C444FE28944DE200036ADE /* ContainerTextField.swift in Sources */,

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A38A6E552890043B007982CF /* SearchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38A6E542890043B007982CF /* SearchManager.swift */; };
 		A3F1480D28882CA90025B822 /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F1480C28882CA90025B822 /* UIImageView.swift */; };
 		B5DB2D66288633E100703587 /* DancerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB2D65288633E100703587 /* DancerCell.swift */; };
+		C011CF4628940446001E6AD1 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C011CF4528940446001E6AD1 /* AuthManager.swift */; };
 		C039DCBA287D940F0007951D /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCB9287D940F0007951D /* MainTabController.swift */; };
 		C039DCBE287D944C0007951D /* ScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCBD287D944C0007951D /* ScheduleViewController.swift */; };
 		C039DCC0287D94630007951D /* SubscriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCBF287D94630007951D /* SubscriptionViewController.swift */; };
@@ -84,6 +85,7 @@
 		A38A6E542890043B007982CF /* SearchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchManager.swift; sourceTree = "<group>"; };
 		A3F1480C28882CA90025B822 /* UIImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
 		B5DB2D65288633E100703587 /* DancerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DancerCell.swift; sourceTree = "<group>"; };
+		C011CF4528940446001E6AD1 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		C039DCB9287D940F0007951D /* MainTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabController.swift; sourceTree = "<group>"; };
 		C039DCBD287D944C0007951D /* ScheduleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleViewController.swift; sourceTree = "<group>"; };
 		C039DCBF287D94630007951D /* SubscriptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionViewController.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				C7CE67D4288FD2F900C8F137 /* DanceClassManager.swift */,
 				C7CE67D6288FD30900C8F137 /* StudioManager.swift */,
 				A38A6E542890043B007982CF /* SearchManager.swift */,
+				C011CF4528940446001E6AD1 /* AuthManager.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -471,6 +474,7 @@
 				A38A4C59287E97CF00614E94 /* SearchDetailViewController.swift in Sources */,
 				A35DE3A128840A2E00A29BA7 /* HistoryCell.swift in Sources */,
 				C05BF1F5287BC7EF00C95E1B /* UIButton.swift in Sources */,
+				C011CF4628940446001E6AD1 /* AuthManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		C07E5C91287E707200BDA46D /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07E5C90287E707200BDA46D /* Genre.swift */; };
 		C08A10B22883BCC1009A38E7 /* MockDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08A10B12883BCC1009A38E7 /* MockDataSet.swift */; };
 		C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */; };
+		C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
 		C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */; };
 		C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE676128814D3C00C8F137 /* Weekday.swift */; };
@@ -125,6 +126,7 @@
 		C07E5C8E287E6D9A00BDA46D /* Studio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Studio.swift; sourceTree = "<group>"; };
 		C07E5C90287E707200BDA46D /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		C08A10B12883BCC1009A38E7 /* MockDataSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataSet.swift; sourceTree = "<group>"; };
+		C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardViewController.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
 		C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdayCell.swift; sourceTree = "<group>"; };
 		C7CE676128814D3C00C8F137 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 		C05BF20A287BCF7F00C95E1B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				C0C7B2852894402D003FA2C2 /* Auth */,
 				C039DCB9287D940F0007951D /* MainTabController.swift */,
 				0ADD3B7E288447B30074C496 /* DancerDetailViewController.swift */,
 				C04B1F082889257D001D2C99 /* WeeklyScheduleCell.swift */,
@@ -341,6 +344,14 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C0C7B2852894402D003FA2C2 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */,
+			);
+			path = Auth;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -437,6 +448,7 @@
 				C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */,
 				C039DCBA287D940F0007951D /* MainTabController.swift in Sources */,
 				C04B1F092889257D001D2C99 /* WeeklyScheduleCell.swift in Sources */,
+				C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */,
 				C07E5C8D287E6D8B00BDA46D /* DanceClass.swift in Sources */,
 				B5DB2D66288633E100703587 /* DancerCell.swift in Sources */,
 				C05BF1F7287BC7EF00C95E1B /* String.swift in Sources */,

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A3F1480D28882CA90025B822 /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F1480C28882CA90025B822 /* UIImageView.swift */; };
 		B5DB2D66288633E100703587 /* DancerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB2D65288633E100703587 /* DancerCell.swift */; };
 		C011CF4628940446001E6AD1 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C011CF4528940446001E6AD1 /* AuthManager.swift */; };
+		C011CF4828940480001E6AD1 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = C011CF4728940480001E6AD1 /* FirebaseAuth */; };
 		C039DCBA287D940F0007951D /* MainTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCB9287D940F0007951D /* MainTabController.swift */; };
 		C039DCBE287D944C0007951D /* ScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCBD287D944C0007951D /* ScheduleViewController.swift */; };
 		C039DCC0287D94630007951D /* SubscriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039DCBF287D94630007951D /* SubscriptionViewController.swift */; };
@@ -141,6 +142,7 @@
 				C040218C287EB8DB009D9083 /* FirebaseFirestore in Frameworks */,
 				C040218E287EB8DB009D9083 /* FirebaseStorage in Frameworks */,
 				C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */,
+				C011CF4828940480001E6AD1 /* FirebaseAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -361,6 +363,7 @@
 				C040218B287EB8DB009D9083 /* FirebaseFirestore */,
 				C040218D287EB8DB009D9083 /* FirebaseStorage */,
 				C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */,
+				C011CF4728940480001E6AD1 /* FirebaseAuth */,
 			);
 			productName = Hypeclass;
 			productReference = C05BF1C5287BC33100C95E1B /* Hypeclass.app */;
@@ -703,6 +706,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		C011CF4728940480001E6AD1 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C040218A287EB8DB009D9083 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
 		C040218B287EB8DB009D9083 /* FirebaseFirestore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C040218A287EB8DB009D9083 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		C08A10B22883BCC1009A38E7 /* MockDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08A10B12883BCC1009A38E7 /* MockDataSet.swift */; };
 		C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */; };
 		C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */; };
+		C0C7B28928944395003FA2C2 /* CTAButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28828944395003FA2C2 /* CTAButton.swift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
 		C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */; };
 		C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE676128814D3C00C8F137 /* Weekday.swift */; };
@@ -127,6 +128,7 @@
 		C07E5C90287E707200BDA46D /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		C08A10B12883BCC1009A38E7 /* MockDataSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataSet.swift; sourceTree = "<group>"; };
 		C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardViewController.swift; sourceTree = "<group>"; };
+		C0C7B28828944395003FA2C2 /* CTAButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTAButton.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
 		C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdayCell.swift; sourceTree = "<group>"; };
 		C7CE676128814D3C00C8F137 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				A31C3F462882AC38005A6F6E /* Separator.swift */,
 				C05BF1FC287BC88400C95E1B /* IndicatorView.swift */,
 				C76C91C5289143C100703CCD /* ItemCell.swift */,
+				C0C7B28828944395003FA2C2 /* CTAButton.swift */,
 			);
 			path = ReusableComponent;
 			sourceTree = "<group>";
@@ -489,6 +492,7 @@
 				A38A4C59287E97CF00614E94 /* SearchDetailViewController.swift in Sources */,
 				A35DE3A128840A2E00A29BA7 /* HistoryCell.swift in Sources */,
 				C05BF1F5287BC7EF00C95E1B /* UIButton.swift in Sources */,
+				C0C7B28928944395003FA2C2 /* CTAButton.swift in Sources */,
 				C011CF4628940446001E6AD1 /* AuthManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		C08A10B22883BCC1009A38E7 /* MockDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08A10B12883BCC1009A38E7 /* MockDataSet.swift */; };
 		C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */; };
 		C0C444FC2894495D00036ADE /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FB2894495D00036ADE /* AuthViewController.swift */; };
+		C0C444FE28944DE200036ADE /* ContainerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FD28944DE200036ADE /* ContainerTextField.swift */; };
 		C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */; };
 		C0C7B28928944395003FA2C2 /* CTAButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28828944395003FA2C2 /* CTAButton.swift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
@@ -129,6 +130,7 @@
 		C07E5C90287E707200BDA46D /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		C08A10B12883BCC1009A38E7 /* MockDataSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataSet.swift; sourceTree = "<group>"; };
 		C0C444FB2894495D00036ADE /* AuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
+		C0C444FD28944DE200036ADE /* ContainerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTextField.swift; sourceTree = "<group>"; };
 		C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardViewController.swift; sourceTree = "<group>"; };
 		C0C7B28828944395003FA2C2 /* CTAButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTAButton.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				C05BF1FC287BC88400C95E1B /* IndicatorView.swift */,
 				C76C91C5289143C100703CCD /* ItemCell.swift */,
 				C0C7B28828944395003FA2C2 /* CTAButton.swift */,
+				C0C444FD28944DE200036ADE /* ContainerTextField.swift */,
 			);
 			path = ReusableComponent;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				C07E5C91287E707200BDA46D /* Genre.swift in Sources */,
 				C05BF1F8287BC7EF00C95E1B /* UIImage.swift in Sources */,
 				C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */,
+				C0C444FE28944DE200036ADE /* ContainerTextField.swift in Sources */,
 				C7CE67D5288FD2F900C8F137 /* DanceClassManager.swift in Sources */,
 				A37F02C7288842640027D3FC /* SearchDetailCell.swift in Sources */,
 				A3F1480D28882CA90025B822 /* UIImageView.swift in Sources */,

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		C07E5C91287E707200BDA46D /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07E5C90287E707200BDA46D /* Genre.swift */; };
 		C08A10B22883BCC1009A38E7 /* MockDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08A10B12883BCC1009A38E7 /* MockDataSet.swift */; };
 		C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */; };
+		C0C444FC2894495D00036ADE /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C444FB2894495D00036ADE /* AuthViewController.swift */; };
 		C0C7B28728944044003FA2C2 /* AuthOnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */; };
 		C0C7B28928944395003FA2C2 /* CTAButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C7B28828944395003FA2C2 /* CTAButton.swift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
@@ -127,6 +128,7 @@
 		C07E5C8E287E6D9A00BDA46D /* Studio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Studio.swift; sourceTree = "<group>"; };
 		C07E5C90287E707200BDA46D /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		C08A10B12883BCC1009A38E7 /* MockDataSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataSet.swift; sourceTree = "<group>"; };
+		C0C444FB2894495D00036ADE /* AuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
 		C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardViewController.swift; sourceTree = "<group>"; };
 		C0C7B28828944395003FA2C2 /* CTAButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTAButton.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 			isa = PBXGroup;
 			children = (
 				C0C7B28628944044003FA2C2 /* AuthOnboardViewController.swift */,
+				C0C444FB2894495D00036ADE /* AuthViewController.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -461,6 +464,7 @@
 				97C17C86288738A300A510CA /* MainViewController+GenreCell.swift in Sources */,
 				C05BF203287BC99A00C95E1B /* BaseViewController.swift in Sources */,
 				C05BF1CB287BC33100C95E1B /* SceneDelegate.swift in Sources */,
+				C0C444FC2894495D00036ADE /* AuthViewController.swift in Sources */,
 				C05BF209287BCAD900C95E1B /* Dancer.swift in Sources */,
 				C039DCBE287D944C0007951D /* ScheduleViewController.swift in Sources */,
 				C7CE67D3288FD2EA00C8F137 /* DancerManager.swift in Sources */,

--- a/Hypeclass/API/AuthManager.swift
+++ b/Hypeclass/API/AuthManager.swift
@@ -13,6 +13,8 @@ class AuthManager {
     static let shared = AuthManager()
     
     var verificationID: String?
+    var userName: String?
+    var phoneNumber: String?
     var currentUser: User? { Auth.auth().currentUser }
     var isLogin: Bool { currentUser != nil }
     

--- a/Hypeclass/API/AuthManager.swift
+++ b/Hypeclass/API/AuthManager.swift
@@ -6,3 +6,66 @@
 //
 
 import Foundation
+import FirebaseAuth
+
+class AuthManager {
+    
+    static let shared = AuthManager()
+    
+    var verificationID: String?
+    var currentUser: User? { Auth.auth().currentUser }
+    var isLogin: Bool { currentUser != nil }
+    
+    private init() {
+        Auth.auth().languageCode = "ko-KR"; // SMS 전송시 한국말 언어 설정 - BCP-47 을 따름
+    }
+    
+    // MARK: - 인증번호 전송 요청
+    
+    func requestVerificationCode(phoneNumber: String) {
+        UserDefaults.standard.set(phoneNumber, forKey: "phoneNumber")
+        let subString = phoneNumber.substring(from: 3, to: 11)
+        let globalNumString = "+8210\(subString)"
+        PhoneAuthProvider.provider()
+            .verifyPhoneNumber(globalNumString, uiDelegate: nil) { verificationID, error in
+                if let error = error {
+                    print("ERROR: \(error.localizedDescription)")
+                } else {
+                    self.verificationID = verificationID
+                    print("DEBUG: success - verify phoneNumber ")
+                }
+            }
+    }
+    
+    //MARK: - 회원가입
+    
+    func signInWith(verificationCode: String) async throws -> AuthDataResult? {
+        guard let verificationID = self.verificationID else {
+            throw AuthError.noVerificationID
+        }
+        let credential = PhoneAuthProvider.provider().credential(
+            withVerificationID: verificationID,
+            verificationCode: verificationCode
+        )
+        
+        let result = try await Auth.auth().signIn(with: credential)
+        // UserDocument 생성 및 전화번호 데이터 저장.
+        
+        return result
+    }
+    
+
+    //MARK: - 회원탈퇴
+    
+    func deleteAccout() async throws {
+        guard let currentUser = self.currentUser else {
+            throw AuthError.noCurrentUser
+        }
+        try await currentUser.delete()
+    }
+}
+
+enum AuthError: Error {
+    case noCurrentUser
+    case noVerificationID
+}

--- a/Hypeclass/API/AuthManager.swift
+++ b/Hypeclass/API/AuthManager.swift
@@ -1,0 +1,8 @@
+//
+//  AuthManager.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/29.
+//
+
+import Foundation

--- a/Hypeclass/Source/Auth/AuthOnboardViewController.swift
+++ b/Hypeclass/Source/Auth/AuthOnboardViewController.swift
@@ -33,6 +33,7 @@ class AuthOnboardViewController: BaseViewController {
     private let ctaButton: CTAButton = {
         let button = CTAButton(title: "시작하기")
         button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
+        
         return button
     }()
     

--- a/Hypeclass/Source/Auth/AuthOnboardViewController.swift
+++ b/Hypeclass/Source/Auth/AuthOnboardViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class AuthOnboardViewController: BaseViewController {
-    
 
     //MARK: - Properties
     
@@ -33,21 +32,26 @@ class AuthOnboardViewController: BaseViewController {
     
     private let ctaButton: CTAButton = {
         let button = CTAButton(title: "시작하기")
-        button.addTarget(button, action: #selector(ctaButtonTap), for: .touchUpInside)
+        button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
         return button
     }()
     
     //MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
     }
+    
     //MARK: - Selectors
     
     @objc func ctaButtonTap() {
-        print("DEBUG: CTAButton Tapp")
+        let vc = AuthViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
+    
     //MARK: - Helpers
+    
     func configureUI() {
         //레이아웃 구성
         let safeArea = view.safeAreaLayoutGuide
@@ -55,7 +59,7 @@ class AuthOnboardViewController: BaseViewController {
         view.addSubview(primaryLabel)
         primaryLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            primaryLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 100),
+            primaryLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 150),
             primaryLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25)
         ])
         

--- a/Hypeclass/Source/Auth/AuthOnboardViewController.swift
+++ b/Hypeclass/Source/Auth/AuthOnboardViewController.swift
@@ -31,15 +31,28 @@ class AuthOnboardViewController: BaseViewController {
         return label
     }()
     
+    private let ctaButton: CTAButton = {
+        let button = CTAButton(title: "시작하기")
+        button.frame = CGRect(x: 0, y: 0, width: 300, height: 60)
+        button.addTarget(button, action: #selector(ctaButtonTap), for: .touchUpInside)
+        return button
+    }()
+    
     //MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
     }
     //MARK: - Selectors
+    
+    @objc func ctaButtonTap() {
+        print("DEBUG: CTAButton Tapp")
+    }
     //MARK: - Helpers
     func configureUI() {
         //레이아웃 구성
+        let safeArea = view.safeAreaLayoutGuide
+        
         view.addSubview(primaryLabel)
         primaryLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -52,6 +65,15 @@ class AuthOnboardViewController: BaseViewController {
         NSLayoutConstraint.activate([
             secondaryLabel.topAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: 20),
             secondaryLabel.leadingAnchor.constraint(equalTo: primaryLabel.leadingAnchor)
+        ])
+        
+        view.addSubview(ctaButton)
+        ctaButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ctaButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
+            ctaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            ctaButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -20),
+            ctaButton.heightAnchor.constraint(equalToConstant: 50)
         ])
     }
 }
@@ -73,5 +95,6 @@ struct AuthOnboardViewControllerRepresentable: UIViewControllerRepresentable {
 struct AuthOnboardViewControllerPreview: PreviewProvider {
     static var previews: some View {
         AuthOnboardViewControllerRepresentable()
+            .preferredColorScheme(.dark)
     }
 }

--- a/Hypeclass/Source/Auth/AuthOnboardViewController.swift
+++ b/Hypeclass/Source/Auth/AuthOnboardViewController.swift
@@ -33,7 +33,6 @@ class AuthOnboardViewController: BaseViewController {
     
     private let ctaButton: CTAButton = {
         let button = CTAButton(title: "시작하기")
-        button.frame = CGRect(x: 0, y: 0, width: 300, height: 60)
         button.addTarget(button, action: #selector(ctaButtonTap), for: .touchUpInside)
         return button
     }()

--- a/Hypeclass/Source/Auth/AuthOnboardViewController.swift
+++ b/Hypeclass/Source/Auth/AuthOnboardViewController.swift
@@ -1,0 +1,77 @@
+//
+//  AuthOnboardViewController.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/30.
+//
+
+import UIKit
+
+class AuthOnboardViewController: BaseViewController {
+    
+
+    //MARK: - Properties
+    
+    private let primaryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "댄서들의 클래스 수강신청\n디라이트에서 간편하게"
+        label.numberOfLines = 2
+        label.font = UIFont.systemFont(ofSize: 24, weight: .semibold)
+        
+        return label
+    }()
+    
+    private let secondaryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "한번 회원가입하고,\n버튼하나로 간단하게 수업을 신청하세요."
+        label.numberOfLines = 2
+        label.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .secondaryLabel
+        
+        return label
+    }()
+    
+    //MARK: - LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    //MARK: - Selectors
+    //MARK: - Helpers
+    func configureUI() {
+        //레이아웃 구성
+        view.addSubview(primaryLabel)
+        primaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            primaryLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 100),
+            primaryLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25)
+        ])
+        
+        view.addSubview(secondaryLabel)
+        secondaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            secondaryLabel.topAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: 20),
+            secondaryLabel.leadingAnchor.constraint(equalTo: primaryLabel.leadingAnchor)
+        ])
+    }
+}
+
+//MARK: - Preview
+import SwiftUI
+
+struct AuthOnboardViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = AuthOnboardViewController
+
+    func makeUIViewController(context: Context) -> AuthOnboardViewController {
+        return AuthOnboardViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: AuthOnboardViewController, context: Context) {}
+}
+
+@available(iOS 13.0.0, *)
+struct AuthOnboardViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        AuthOnboardViewControllerRepresentable()
+    }
+}

--- a/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
+++ b/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
@@ -15,6 +15,7 @@ class AuthPhoneNumberViewController: BaseViewController {
         let label = UILabel()
         label.text = "전화번호를 알려주세요."
         label.font = UIFont.boldSystemFont(ofSize: 24)
+        
         return label
     }()
     
@@ -22,6 +23,7 @@ class AuthPhoneNumberViewController: BaseViewController {
         let view = UIView()
         view.backgroundColor = .container
         view.layer.cornerRadius = 8
+        
         return view
     }()
     
@@ -34,6 +36,7 @@ class AuthPhoneNumberViewController: BaseViewController {
         textField.frame.size = CGSize(width: 300, height: 50)
         textField.keyboardType = .numberPad
         textField.addDoneButtonOnKeyboard()
+        
         return textField
     }()
     
@@ -42,12 +45,14 @@ class AuthPhoneNumberViewController: BaseViewController {
         label.text = " "
         label.font = UIFont.boldSystemFont(ofSize: 14)
         label.textColor = .secondaryLabel
+        
         return label
     }()
     
     private let ctaButton: CTAButton = {
         let button = CTAButton(title: "시작하기")
         button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
+        
         return button
     }()
     

--- a/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
+++ b/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
@@ -1,0 +1,42 @@
+//
+//  AuthPhoneNumberViewController.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/30.
+//
+
+import UIKit
+
+class AuthPhoneNumberViewController: BaseViewController {
+    //MARK: - Properties
+    //MARK: - LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    //MARK: - Selectors
+    //MARK: - Helpers
+    func configureUI() {
+        //레이아웃 구성
+    }
+}
+
+//MARK: - Preview
+import SwiftUI
+
+struct AuthPhoneNumberViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = AuthPhoneNumberViewController
+
+    func makeUIViewController(context: Context) -> AuthPhoneNumberViewController {
+        return AuthPhoneNumberViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: AuthPhoneNumberViewController, context: Context) {}
+}
+
+@available(iOS 13.0.0, *)
+struct AuthPhoneNumberViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        AuthPhoneNumberViewControllerRepresentable()
+    }
+}

--- a/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
+++ b/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
@@ -9,15 +9,122 @@ import UIKit
 
 class AuthPhoneNumberViewController: BaseViewController {
     //MARK: - Properties
+    
+    private let primaryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "신청자의 이름을 알려주세요."
+        label.font = UIFont.boldSystemFont(ofSize: 24)
+        return label
+    }()
+    
+    private let textFieldContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .container
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let textField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "이름"
+        textField.font = UIFont.boldSystemFont(ofSize: 16)
+        textField.textColor = .white
+        textField.tintColor = .label
+        textField.frame.size = CGSize(width: 300, height: 50)
+        textField.addDoneButtonOnKeyboard()
+        return textField
+    }()
+    
+    private let phoneNumberContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .container
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let phoneNumberField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "전화번호"
+        textField.font = UIFont.boldSystemFont(ofSize: 16)
+        textField.textColor = .white
+        textField.tintColor = .label
+        textField.frame.size = CGSize(width: 300, height: 50)
+        return textField
+    }()
+    
+    private let inputInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "반드시 본명을 입력해주세요."
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+    
+    private let ctaButton: CTAButton = {
+        let button = CTAButton(title: "다음")
+        button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
+        return button
+    }()
+    
     //MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        dismissKeyboardWhenTappedAround()
+
     }
     //MARK: - Selectors
+    
+    @objc func ctaButtonTap() {
+        print("DEBUG: CTAButton Tapp")
+        AuthManager.shared.userName = textField.text
+    }
+    
     //MARK: - Helpers
     func configureUI() {
         //레이아웃 구성
+        let safeArea = view.safeAreaLayoutGuide
+        
+        view.addSubview(primaryLabel)
+        primaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            primaryLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 60),
+            primaryLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 25)
+        ])
+        
+        view.addSubview(inputInfoLabel)
+        inputInfoLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            inputInfoLabel.topAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: 30),
+            inputInfoLabel.leadingAnchor.constraint(equalTo: primaryLabel.leadingAnchor)
+        ])
+        
+        view.addSubview(textFieldContainer)
+        textFieldContainer.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldContainer.topAnchor.constraint(equalTo: inputInfoLabel.bottomAnchor, constant: 10),
+            textFieldContainer.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
+            textFieldContainer.heightAnchor.constraint(equalToConstant: 50),
+            textFieldContainer.leadingAnchor.constraint(equalTo: inputInfoLabel.leadingAnchor),
+            textFieldContainer.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -25)
+        ])
+        
+        textFieldContainer.addSubview(textField)
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 20),
+            textField.centerYAnchor.constraint(equalTo: textFieldContainer.centerYAnchor),
+            textField.trailingAnchor.constraint(equalTo: textFieldContainer.trailingAnchor, constant: -20)
+        ])
+        
+        view.addSubview(ctaButton)
+        ctaButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ctaButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
+            ctaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            ctaButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -20),
+            ctaButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
     }
 }
 

--- a/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
+++ b/Hypeclass/Source/Auth/AuthPhoneNumberViewController.swift
@@ -8,11 +8,12 @@
 import UIKit
 
 class AuthPhoneNumberViewController: BaseViewController {
+    
     //MARK: - Properties
     
     private let primaryLabel: UILabel = {
         let label = UILabel()
-        label.text = "신청자의 이름을 알려주세요."
+        label.text = "전화번호를 알려주세요."
         label.font = UIFont.boldSystemFont(ofSize: 24)
         return label
     }()
@@ -26,58 +27,45 @@ class AuthPhoneNumberViewController: BaseViewController {
     
     private let textField: UITextField = {
         let textField = UITextField()
-        textField.placeholder = "이름"
+        textField.placeholder = "인증번호"
         textField.font = UIFont.boldSystemFont(ofSize: 16)
         textField.textColor = .white
         textField.tintColor = .label
         textField.frame.size = CGSize(width: 300, height: 50)
+        textField.keyboardType = .numberPad
         textField.addDoneButtonOnKeyboard()
-        return textField
-    }()
-    
-    private let phoneNumberContainer: UIView = {
-        let view = UIView()
-        view.backgroundColor = .container
-        view.layer.cornerRadius = 8
-        return view
-    }()
-    
-    private let phoneNumberField: UITextField = {
-        let textField = UITextField()
-        textField.placeholder = "전화번호"
-        textField.font = UIFont.boldSystemFont(ofSize: 16)
-        textField.textColor = .white
-        textField.tintColor = .label
-        textField.frame.size = CGSize(width: 300, height: 50)
         return textField
     }()
     
     private let inputInfoLabel: UILabel = {
         let label = UILabel()
-        label.text = "반드시 본명을 입력해주세요."
+        label.text = " "
         label.font = UIFont.boldSystemFont(ofSize: 14)
         label.textColor = .secondaryLabel
         return label
     }()
     
     private let ctaButton: CTAButton = {
-        let button = CTAButton(title: "다음")
+        let button = CTAButton(title: "시작하기")
         button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
         return button
     }()
     
     //MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
         dismissKeyboardWhenTappedAround()
 
     }
+    
     //MARK: - Selectors
     
     @objc func ctaButtonTap() {
         print("DEBUG: CTAButton Tapp")
-        AuthManager.shared.userName = textField.text
+        let vc = AuthVerificationController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     //MARK: - Helpers

--- a/Hypeclass/Source/Auth/AuthVerificationController.swift
+++ b/Hypeclass/Source/Auth/AuthVerificationController.swift
@@ -8,16 +8,108 @@
 import UIKit
 
 class AuthVerificationController: BaseViewController {
+    
     //MARK: - Properties
+    
+    private let primaryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "인증번호를 입력해주세요."
+        label.font = UIFont.boldSystemFont(ofSize: 24)
+        return label
+    }()
+    
+    private let textFieldContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .container
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let textField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "전화번호"
+        textField.font = UIFont.boldSystemFont(ofSize: 16)
+        textField.textColor = .white
+        textField.tintColor = .label
+        textField.frame.size = CGSize(width: 300, height: 50)
+        textField.keyboardType = .numberPad
+        textField.addDoneButtonOnKeyboard()
+        return textField
+    }()
+    
+    private let inputInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "인증번호 6자리"
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+    
+    private let ctaButton: CTAButton = {
+        let button = CTAButton(title: "시작하기")
+        button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
+        return button
+    }()
+    
     //MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        dismissKeyboardWhenTappedAround()
     }
+    
     //MARK: - Selectors
+    
+    @objc func ctaButtonTap() {
+        self.dismiss(animated: true)
+    }
+    
     //MARK: - Helpers
     func configureUI() {
         //레이아웃 구성
+        let safeArea = view.safeAreaLayoutGuide
+        
+        view.addSubview(primaryLabel)
+        primaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            primaryLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 60),
+            primaryLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 25)
+        ])
+        
+        view.addSubview(inputInfoLabel)
+        inputInfoLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            inputInfoLabel.topAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: 30),
+            inputInfoLabel.leadingAnchor.constraint(equalTo: primaryLabel.leadingAnchor)
+        ])
+        
+        view.addSubview(textFieldContainer)
+        textFieldContainer.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldContainer.topAnchor.constraint(equalTo: inputInfoLabel.bottomAnchor, constant: 10),
+            textFieldContainer.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
+            textFieldContainer.heightAnchor.constraint(equalToConstant: 50),
+            textFieldContainer.leadingAnchor.constraint(equalTo: inputInfoLabel.leadingAnchor),
+            textFieldContainer.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -25)
+        ])
+        
+        textFieldContainer.addSubview(textField)
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 20),
+            textField.centerYAnchor.constraint(equalTo: textFieldContainer.centerYAnchor),
+            textField.trailingAnchor.constraint(equalTo: textFieldContainer.trailingAnchor, constant: -20)
+        ])
+        
+        view.addSubview(ctaButton)
+        ctaButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ctaButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
+            ctaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            ctaButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -20),
+            ctaButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
     }
 }
 

--- a/Hypeclass/Source/Auth/AuthVerificationController.swift
+++ b/Hypeclass/Source/Auth/AuthVerificationController.swift
@@ -15,6 +15,7 @@ class AuthVerificationController: BaseViewController {
         let label = UILabel()
         label.text = "인증번호를 입력해주세요."
         label.font = UIFont.boldSystemFont(ofSize: 24)
+        
         return label
     }()
     
@@ -22,6 +23,7 @@ class AuthVerificationController: BaseViewController {
         let view = UIView()
         view.backgroundColor = .container
         view.layer.cornerRadius = 8
+        
         return view
     }()
     
@@ -34,6 +36,7 @@ class AuthVerificationController: BaseViewController {
         textField.frame.size = CGSize(width: 300, height: 50)
         textField.keyboardType = .numberPad
         textField.addDoneButtonOnKeyboard()
+        
         return textField
     }()
     
@@ -42,12 +45,14 @@ class AuthVerificationController: BaseViewController {
         label.text = "인증번호 6자리"
         label.font = UIFont.boldSystemFont(ofSize: 14)
         label.textColor = .secondaryLabel
+        
         return label
     }()
     
     private let ctaButton: CTAButton = {
         let button = CTAButton(title: "시작하기")
         button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
+        
         return button
     }()
     

--- a/Hypeclass/Source/Auth/AuthVerificationController.swift
+++ b/Hypeclass/Source/Auth/AuthVerificationController.swift
@@ -1,0 +1,42 @@
+//
+//  AuthVerificationController.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/30.
+//
+
+import UIKit
+
+class AuthVerificationController: BaseViewController {
+    //MARK: - Properties
+    //MARK: - LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    //MARK: - Selectors
+    //MARK: - Helpers
+    func configureUI() {
+        //레이아웃 구성
+    }
+}
+
+//MARK: - Preview
+import SwiftUI
+
+struct AuthVerificationControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = AuthVerificationController
+
+    func makeUIViewController(context: Context) -> AuthVerificationController {
+        return AuthVerificationController()
+    }
+
+    func updateUIViewController(_ uiViewController: AuthVerificationController, context: Context) {}
+}
+
+@available(iOS 13.0.0, *)
+struct AuthVerificationControllerPreview: PreviewProvider {
+    static var previews: some View {
+        AuthVerificationControllerRepresentable()
+    }
+}

--- a/Hypeclass/Source/Auth/AuthViewController.swift
+++ b/Hypeclass/Source/Auth/AuthViewController.swift
@@ -61,6 +61,8 @@ class AuthViewController: BaseViewController, UITextFieldDelegate {
     
     @objc func ctaButtonTap() {
         AuthManager.shared.userName = textField.text
+        let vc = AuthPhoneNumberViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     //MARK: - Helpers

--- a/Hypeclass/Source/Auth/AuthViewController.swift
+++ b/Hypeclass/Source/Auth/AuthViewController.swift
@@ -1,0 +1,42 @@
+//
+//  AuthViewController.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/30.
+//
+
+import UIKit
+
+class AuthViewController: BaseViewController {
+    //MARK: - Properties
+    //MARK: - LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    //MARK: - Selectors
+    //MARK: - Helpers
+    func configureUI() {
+        //레이아웃 구성
+    }
+}
+
+//MARK: - Preview
+import SwiftUI
+
+struct AuthViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = AuthViewController
+
+    func makeUIViewController(context: Context) -> AuthViewController {
+        return AuthViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: AuthViewController, context: Context) {}
+}
+
+@available(iOS 13.0.0, *)
+struct AuthViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        AuthViewControllerRepresentable()
+    }
+}

--- a/Hypeclass/Source/Auth/AuthViewController.swift
+++ b/Hypeclass/Source/Auth/AuthViewController.swift
@@ -17,14 +17,14 @@ class AuthViewController: BaseViewController, UITextFieldDelegate {
         return label
     }()
     
-    private let nameContainer: UIView = {
+    private let textFieldContainer: UIView = {
         let view = UIView()
         view.backgroundColor = .container
         view.layer.cornerRadius = 8
         return view
     }()
     
-    private let nameTextField: UITextField = {
+    private let textField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "이름"
         textField.font = UIFont.boldSystemFont(ofSize: 16)
@@ -32,23 +32,6 @@ class AuthViewController: BaseViewController, UITextFieldDelegate {
         textField.tintColor = .label
         textField.frame.size = CGSize(width: 300, height: 50)
         textField.addDoneButtonOnKeyboard()
-        return textField
-    }()
-    
-    private let phoneNumberContainer: UIView = {
-        let view = UIView()
-        view.backgroundColor = .container
-        view.layer.cornerRadius = 8
-        return view
-    }()
-    
-    private let phoneNumberField: UITextField = {
-        let textField = UITextField()
-        textField.placeholder = "전화번호"
-        textField.font = UIFont.boldSystemFont(ofSize: 16)
-        textField.textColor = .white
-        textField.tintColor = .label
-        textField.frame.size = CGSize(width: 300, height: 50)
         return textField
     }()
     
@@ -72,14 +55,12 @@ class AuthViewController: BaseViewController, UITextFieldDelegate {
         super.viewDidLoad()
         configureUI()
         dismissKeyboardWhenTappedAround()
-        nameTextField.delegate = self
-        phoneNumberField.delegate = self
     }
     
     //MARK: - Selectors
     
     @objc func ctaButtonTap() {
-        print("DEBUG: CTAButton Tapp")
+        AuthManager.shared.userName = textField.text
     }
     
     //MARK: - Helpers
@@ -102,27 +83,23 @@ class AuthViewController: BaseViewController, UITextFieldDelegate {
             inputInfoLabel.leadingAnchor.constraint(equalTo: primaryLabel.leadingAnchor)
         ])
         
-        view.addSubview(nameContainer)
-        nameContainer.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(textFieldContainer)
+        textFieldContainer.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nameContainer.topAnchor.constraint(equalTo: inputInfoLabel.bottomAnchor, constant: 10),
-            nameContainer.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
-            nameContainer.heightAnchor.constraint(equalToConstant: 50),
-            nameContainer.leadingAnchor.constraint(equalTo: inputInfoLabel.leadingAnchor),
-            nameContainer.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -25)
+            textFieldContainer.topAnchor.constraint(equalTo: inputInfoLabel.bottomAnchor, constant: 10),
+            textFieldContainer.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
+            textFieldContainer.heightAnchor.constraint(equalToConstant: 50),
+            textFieldContainer.leadingAnchor.constraint(equalTo: inputInfoLabel.leadingAnchor),
+            textFieldContainer.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -25)
         ])
         
-        nameContainer.addSubview(nameTextField)
-        nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        textFieldContainer.addSubview(textField)
+        textField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nameTextField.leadingAnchor.constraint(equalTo: nameContainer.leadingAnchor, constant: 20),
-            nameTextField.centerYAnchor.constraint(equalTo: nameContainer.centerYAnchor),
-            nameTextField.trailingAnchor.constraint(equalTo: nameContainer.trailingAnchor, constant: -20)
+            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 20),
+            textField.centerYAnchor.constraint(equalTo: textFieldContainer.centerYAnchor),
+            textField.trailingAnchor.constraint(equalTo: textFieldContainer.trailingAnchor, constant: -20)
         ])
-        
-        view.addSubview(phoneNumberContainer)
-        phoneNumberContainer.translatesAutoresizingMaskIntoConstraints = false
-  
         
         view.addSubview(ctaButton)
         ctaButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Hypeclass/Source/Auth/AuthViewController.swift
+++ b/Hypeclass/Source/Auth/AuthViewController.swift
@@ -7,17 +7,131 @@
 
 import UIKit
 
-class AuthViewController: BaseViewController {
+class AuthViewController: BaseViewController, UITextFieldDelegate {
     //MARK: - Properties
+    
+    private let primaryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "신청자의 이름을 알려주세요."
+        label.font = UIFont.boldSystemFont(ofSize: 24)
+        return label
+    }()
+    
+    private let nameContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .container
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let nameTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "이름"
+        textField.font = UIFont.boldSystemFont(ofSize: 16)
+        textField.textColor = .white
+        textField.tintColor = .label
+        textField.frame.size = CGSize(width: 300, height: 50)
+        textField.addDoneButtonOnKeyboard()
+        return textField
+    }()
+    
+    private let phoneNumberContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .container
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let phoneNumberField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "전화번호"
+        textField.font = UIFont.boldSystemFont(ofSize: 16)
+        textField.textColor = .white
+        textField.tintColor = .label
+        textField.frame.size = CGSize(width: 300, height: 50)
+        return textField
+    }()
+    
+    private let inputInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "반드시 본명을 입력해주세요."
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+    
+    private let ctaButton: CTAButton = {
+        let button = CTAButton(title: "다음")
+        button.addTarget(self, action: #selector(ctaButtonTap), for: .touchUpInside)
+        return button
+    }()
+    
     //MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        dismissKeyboardWhenTappedAround()
+        nameTextField.delegate = self
+        phoneNumberField.delegate = self
     }
+    
     //MARK: - Selectors
+    
+    @objc func ctaButtonTap() {
+        print("DEBUG: CTAButton Tapp")
+    }
+    
     //MARK: - Helpers
+    
     func configureUI() {
         //레이아웃 구성
+        let safeArea = view.safeAreaLayoutGuide
+        
+        view.addSubview(primaryLabel)
+        primaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            primaryLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 60),
+            primaryLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 25)
+        ])
+        
+        view.addSubview(inputInfoLabel)
+        inputInfoLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            inputInfoLabel.topAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: 30),
+            inputInfoLabel.leadingAnchor.constraint(equalTo: primaryLabel.leadingAnchor)
+        ])
+        
+        view.addSubview(nameContainer)
+        nameContainer.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nameContainer.topAnchor.constraint(equalTo: inputInfoLabel.bottomAnchor, constant: 10),
+            nameContainer.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
+            nameContainer.heightAnchor.constraint(equalToConstant: 50),
+            nameContainer.leadingAnchor.constraint(equalTo: inputInfoLabel.leadingAnchor),
+            nameContainer.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -25)
+        ])
+        
+        nameContainer.addSubview(nameTextField)
+        nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nameTextField.leadingAnchor.constraint(equalTo: nameContainer.leadingAnchor, constant: 20),
+            nameTextField.centerYAnchor.constraint(equalTo: nameContainer.centerYAnchor),
+            nameTextField.trailingAnchor.constraint(equalTo: nameContainer.trailingAnchor, constant: -20)
+        ])
+        
+        view.addSubview(phoneNumberContainer)
+        phoneNumberContainer.translatesAutoresizingMaskIntoConstraints = false
+  
+        
+        view.addSubview(ctaButton)
+        ctaButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ctaButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
+            ctaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            ctaButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -20),
+            ctaButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
     }
 }
 

--- a/Hypeclass/Util/Extension/UIColor.swift
+++ b/Hypeclass/Util/Extension/UIColor.swift
@@ -21,5 +21,5 @@ extension UIColor {
     
     class var background: UIColor { UIColor(hex: 0x181818) }
     class var accent: UIColor { UIColor(hex: 0xC7FD51) }
-    class var searchBarBackground: UIColor{ UIColor(hex: 0x2D2C38) }
+    class var container: UIColor{ UIColor(hex: 0x2D2C38) }
 }

--- a/Hypeclass/Util/Extension/UITextField.swift
+++ b/Hypeclass/Util/Extension/UITextField.swift
@@ -48,7 +48,7 @@ extension UITextField {
             let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
             let done: UIBarButtonItem = UIBarButtonItem(title:  NSLocalizedString("keyboard_close", comment: ""), style: .done, target: self, action: #selector(self.doneButtonAction))
             done.title = "닫기"
-            done.tintColor = .black
+            done.tintColor = .white
             let items = [flexSpace, done]
             doneToolbar.items = items
             doneToolbar.sizeToFit()

--- a/Hypeclass/Util/ReusableComponent/CTAButton.swift
+++ b/Hypeclass/Util/ReusableComponent/CTAButton.swift
@@ -23,5 +23,6 @@ class CTAButton: UIButton {
         backgroundColor = .accent
         setTitleColor(.black, for: .normal)
         setTitle(title, for: .normal)
+        titleLabel?.font = .boldSystemFont(ofSize: 20)
     }
 }

--- a/Hypeclass/Util/ReusableComponent/CTAButton.swift
+++ b/Hypeclass/Util/ReusableComponent/CTAButton.swift
@@ -1,0 +1,27 @@
+//
+//  CTAButton.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/30.
+//
+
+import UIKit
+
+class CTAButton: UIButton {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    init(title: String) {
+        super.init(frame: CGRect.zero)
+        layer.cornerRadius = 8
+        backgroundColor = .accent
+        setTitleColor(.black, for: .normal)
+        setTitle(title, for: .normal)
+    }
+}

--- a/Hypeclass/Util/ReusableComponent/ContainerTextField.swift
+++ b/Hypeclass/Util/ReusableComponent/ContainerTextField.swift
@@ -1,0 +1,20 @@
+//
+//  ContainerTextField.swift
+//  Hypeclass
+//
+//  Created by GOngTAE on 2022/07/30.
+//
+
+import UIKit
+
+class ContainerTextField: UITextField {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Hypeclass/Util/ReusableComponent/ContainerTextField.swift
+++ b/Hypeclass/Util/ReusableComponent/ContainerTextField.swift
@@ -8,13 +8,16 @@
 import UIKit
 
 class ContainerTextField: UITextField {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    override init(frame: CGRect) {
+        super.init(frame: frame)
     }
-    */
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not implemented")
+    }
+    
+    init() {
+        super.init(frame: CGRect.zero)
+        backgroundColor = .container
+    }
 }

--- a/Hypeclass/Util/ReusableComponent/SearchBar.swift
+++ b/Hypeclass/Util/ReusableComponent/SearchBar.swift
@@ -17,7 +17,7 @@ class SearchBar: UISearchBar {
         self.tintColor = .white
         self.searchTextField.font = UIFont.systemFont(ofSize: 12.0)
         self.searchTextField.textColor = .white
-        self.searchTextField.backgroundColor = .searchBarBackground
+        self.searchTextField.backgroundColor = .container
         self.searchTextField.leftViewMode = .never
         self.returnKeyType = .google
     }


### PR DESCRIPTION
## 개요
- #121 
- #120 
- Firebase 전화번호 인증 로직, 회원가입 뷰 구현

## 작업내용
- AuthManager 생성
  - 전화번호 인증 요청 메서드 구현
  - 인증번호를 사용한 회원가입 메서드 구현
  - 회원 탈퇴 메서드 구현
  - 로그인 여부 확인 가능한 계산 프로퍼티 구현
- 회원가입화면 구현

## 고민사항
- 로직과 뷰를 아직 연결하지 않았습니다.
- ViewController 들 간의 중복코드가 많아 재사용 가능하게 끔 추후 리팩터링 예정입니다

## 이미지(UI 관련작업시)
![Simulator Screen Shot - iPhone 13 - 2022-07-30 at 14 17 11](https://user-images.githubusercontent.com/89325126/181875894-4b95db62-8632-4cef-8cd4-de2518b718d7.png)

