### PR TITLE
[FEAT] StudioViewController 구현

### DIFF
--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		C08A10B22883BCC1009A38E7 /* MockDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08A10B12883BCC1009A38E7 /* MockDataSet.swift */; };
 		C0A9D9BC288FAF15007493A2 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0A9D9BB288FAF15007493A2 /* FirebaseFirestoreSwift */; };
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
+		C76C91CE2894509600703CCD /* StudioViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91CD2894509600703CCD /* StudioViewController.swift */; };
+		C76C91D02894559600703CCD /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91CF2894559600703CCD /* HeaderView.swift */; };
 		C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */; };
 		C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE676128814D3C00C8F137 /* Weekday.swift */; };
 		C7CE67AF2886F70700C8F137 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE67AE2886F70700C8F137 /* ScheduleView.swift */; };
@@ -123,6 +125,8 @@
 		C07E5C90287E707200BDA46D /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		C08A10B12883BCC1009A38E7 /* MockDataSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataSet.swift; sourceTree = "<group>"; };
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
+		C76C91CD2894509600703CCD /* StudioViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudioViewController.swift; sourceTree = "<group>"; };
+		C76C91CF2894559600703CCD /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdayCell.swift; sourceTree = "<group>"; };
 		C7CE676128814D3C00C8F137 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		C7CE67AE2886F70700C8F137 /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
@@ -152,6 +156,7 @@
 				A31C3F462882AC38005A6F6E /* Separator.swift */,
 				C05BF1FC287BC88400C95E1B /* IndicatorView.swift */,
 				C76C91C5289143C100703CCD /* ItemCell.swift */,
+				C76C91CF2894559600703CCD /* HeaderView.swift */,
 			);
 			path = ReusableComponent;
 			sourceTree = "<group>";
@@ -310,6 +315,7 @@
 		C05BF20A287BCF7F00C95E1B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				C76C91CC2894504500703CCD /* Studio */,
 				C039DCB9287D940F0007951D /* MainTabController.swift */,
 				0ADD3B7E288447B30074C496 /* DancerDetailViewController.swift */,
 				C04B1F082889257D001D2C99 /* WeeklyScheduleCell.swift */,
@@ -336,6 +342,14 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C76C91CC2894504500703CCD /* Studio */ = {
+			isa = PBXGroup;
+			children = (
+				C76C91CD2894509600703CCD /* StudioViewController.swift */,
+			);
+			path = Studio;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -428,6 +442,7 @@
 				0AA1E7DE288EE32A00AC0CE9 /* DancerDetailScheduleModel.swift in Sources */,
 				0AA1E7E0288EE3F600AC0CE9 /* DancerDetailSchduleManager.swift in Sources */,
 				C05BF1FA287BC7EF00C95E1B /* UIColor.swift in Sources */,
+				C76C91CE2894509600703CCD /* StudioViewController.swift in Sources */,
 				C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */,
 				C039DCBA287D940F0007951D /* MainTabController.swift in Sources */,
 				C04B1F092889257D001D2C99 /* WeeklyScheduleCell.swift in Sources */,
@@ -461,6 +476,7 @@
 				C07E5C91287E707200BDA46D /* Genre.swift in Sources */,
 				C05BF1F8287BC7EF00C95E1B /* UIImage.swift in Sources */,
 				C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */,
+				C76C91D02894559600703CCD /* HeaderView.swift in Sources */,
 				C7CE67D5288FD2F900C8F137 /* DanceClassManager.swift in Sources */,
 				A37F02C7288842640027D3FC /* SearchDetailCell.swift in Sources */,
 				A3F1480D28882CA90025B822 /* UIImageView.swift in Sources */,

--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		C76C91C6289143C100703CCD /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C5289143C100703CCD /* ItemCell.swift */; };
 		C76C91CE2894509600703CCD /* StudioViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91CD2894509600703CCD /* StudioViewController.swift */; };
 		C76C91D02894559600703CCD /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91CF2894559600703CCD /* HeaderView.swift */; };
+		C76C91D228951E3900703CCD /* TabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91D128951E3800703CCD /* TabCell.swift */; };
 		C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */; };
 		C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE676128814D3C00C8F137 /* Weekday.swift */; };
 		C7CE67AF2886F70700C8F137 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE67AE2886F70700C8F137 /* ScheduleView.swift */; };
@@ -127,6 +128,7 @@
 		C76C91C5289143C100703CCD /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
 		C76C91CD2894509600703CCD /* StudioViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudioViewController.swift; sourceTree = "<group>"; };
 		C76C91CF2894559600703CCD /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
+		C76C91D128951E3800703CCD /* TabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCell.swift; sourceTree = "<group>"; };
 		C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdayCell.swift; sourceTree = "<group>"; };
 		C7CE676128814D3C00C8F137 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		C7CE67AE2886F70700C8F137 /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 			isa = PBXGroup;
 			children = (
 				C76C91CD2894509600703CCD /* StudioViewController.swift */,
+				C76C91D128951E3800703CCD /* TabCell.swift */,
 			);
 			path = Studio;
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 				0AA1E7E0288EE3F600AC0CE9 /* DancerDetailSchduleManager.swift in Sources */,
 				C05BF1FA287BC7EF00C95E1B /* UIColor.swift in Sources */,
 				C76C91CE2894509600703CCD /* StudioViewController.swift in Sources */,
+				C76C91D228951E3900703CCD /* TabCell.swift in Sources */,
 				C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */,
 				C039DCBA287D940F0007951D /* MainTabController.swift in Sources */,
 				C04B1F092889257D001D2C99 /* WeeklyScheduleCell.swift in Sources */,

--- a/Hypeclass/API/StudioManager.swift
+++ b/Hypeclass/API/StudioManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FirebaseFirestore
 
 class StudioManager {
     static let shared = StudioManager()
@@ -43,5 +44,17 @@ class StudioManager {
         return snapshot.documents.compactMap { document in
             try? document.data(as: Studio.self)
         }
+    }
+    
+    func incrementLikes(studioName name: String) {
+        Constant.studioRef.document(name).updateData([
+            "likes": FieldValue.increment(Int64(1))
+        ])
+    }
+    
+    func decrementLikes(studioName name: String) {
+        Constant.studioRef.document(name).updateData([
+            "likes": FieldValue.increment(Int64(-1))
+        ])
     }
 }

--- a/Hypeclass/API/StudioManager.swift
+++ b/Hypeclass/API/StudioManager.swift
@@ -14,7 +14,7 @@ class StudioManager {
     static var myStudios: [Studio]?
     
     func createStudio(id: String, name: String, dancers: [String]) {
-        let studio = Studio(id: id, name: name, description: "\(name) description", instagramURL: nil, youtubeURL: nil, dancers: dancers)
+        let studio = Studio(id: id, name: name, description: "\(name) description", instagramURL: nil, youtubeURL: nil, dancers: dancers, likes: nil)
         do {
             try Constant.studioRef.document("\(name)").setData(from: studio)
         } catch let error {

--- a/Hypeclass/Model/Studio.swift
+++ b/Hypeclass/Model/Studio.swift
@@ -14,4 +14,5 @@ struct Studio: Codable {
     let instagramURL: String?
     let youtubeURL: String?
     let dancers: [String]?
+    let likes: Int?
 }

--- a/Hypeclass/Source/Main/MainViewController.swift
+++ b/Hypeclass/Source/Main/MainViewController.swift
@@ -143,7 +143,7 @@ class MainViewController: BaseViewController {
     // MARK: - Selectors
     
     @objc func searchButtonDidTap() {
-        let searchVC = StudioViewController()
+        let searchVC = SearchViewController()
         self.navigationController?.pushViewController(searchVC, animated: true)
     }
     

--- a/Hypeclass/Source/Main/MainViewController.swift
+++ b/Hypeclass/Source/Main/MainViewController.swift
@@ -143,7 +143,7 @@ class MainViewController: BaseViewController {
     // MARK: - Selectors
     
     @objc func searchButtonDidTap() {
-        let searchVC = SearchViewController()
+        let searchVC = StudioViewController()
         self.navigationController?.pushViewController(searchVC, animated: true)
     }
     

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -1,0 +1,92 @@
+//
+//  StudioViewController.swift
+//  Hypeclass
+//
+//  Created by Jiyoung Park on 2022/07/30.
+//
+
+import UIKit
+
+class StudioViewController: BaseViewController {
+    
+    //MARK: - Properties
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        
+        return scrollView
+    }()
+    
+    private let contentView: UIView = {
+        let view = UIView()
+        
+        return view
+    }()
+    
+    private var studioHeaderView = HeaderView(frame: .zero, coverImageURL: nil, profileImageURL: nil, title: "HIGGS STUDIO", subtitle: "서울특별시 관악구 솔밭로 1 지하 1층", instagramURL: "https://instagram.com/dann.oao")
+    
+    //MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        self.scrollView.contentInsetAdjustmentBehavior = .never;
+    }
+    
+    //MARK: - Selectors
+    
+    //MARK: - Helpers
+    
+    private func configureUI() {
+        // scrollView
+        view.addSubview(scrollView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        
+        // contentView
+        scrollView.addSubview(contentView)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.topAnchor.constraint(equalTo: scrollView.topAnchor).isActive = true
+        contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor).isActive = true
+        contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor).isActive = true
+        contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor).isActive = true
+        contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
+
+        let contentViewHeight = contentView.heightAnchor.constraint(greaterThanOrEqualTo: view.heightAnchor)
+        contentViewHeight.priority = .defaultLow
+        contentViewHeight.isActive = true
+        
+        // studioHeaderView
+        contentView.addSubview(studioHeaderView)
+        studioHeaderView.translatesAutoresizingMaskIntoConstraints = false
+        studioHeaderView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        studioHeaderView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        studioHeaderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+
+    }
+    
+}
+
+//MARK: - Preview
+import SwiftUI
+
+struct StudioViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = StudioViewController
+
+    func makeUIViewController(context: Context) -> StudioViewController {
+        return StudioViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: StudioViewController, context: Context) {
+    }
+}
+
+@available(iOS 13.0.0, *)
+struct StudioViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        StudioViewControllerRepresentable()
+    }
+}

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -132,6 +132,13 @@ class StudioViewController: BaseViewController {
     
     @objc func backButtonDidTap() {
         self.navigationController?.popViewController(animated: true)
+        if remoteHeartState != isHeart {
+            if isHeart {
+                addToSubscription()
+            } else {
+                removeFromSubscription()
+            }
+        }
     }
     
     @objc func heartDidTap() {
@@ -139,11 +146,9 @@ class StudioViewController: BaseViewController {
         if isHeart {
             heartView.image = UIImage(systemName: "heart.fill")
             presentBottomAlert(message: "스튜디오를 구독하였습니다.")
-            addToSubscription()
         } else {
             heartView.image = UIImage(systemName: "heart")
             presentBottomAlert(message: "스튜디오 구독이 취소되었습니다.")
-            removeFromSubscription()
         }
     }
     
@@ -301,6 +306,7 @@ class StudioViewController: BaseViewController {
         
         let subscriptions = UserDefaults.standard.stringArray(forKey: "SubscribedStudios")!.filter { $0 != studio!.id }
         UserDefaults.standard.set(subscriptions, forKey: "SubscribedStudios")
+        StudioManager.myStudios = StudioManager.myStudios?.filter { $0.id != studio!.id }
     }
     
     func moveIndicator(index: Int) {

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -47,11 +47,13 @@ class StudioViewController: BaseViewController {
         return view
     }()
     
+    private var remoteHeartState = false
+    
     private var isHeart = false
     
-    private let studioID = "81DB67B8-9CAC-4AFE-B261-75BF7EE54534"
+    var studio: Studio?
     
-    private var studioHeaderView = HeaderView(frame: .zero, coverImageURL: nil, profileImageURL: nil, title: "HIGGS STUDIO", subtitle: "서울특별시 관악구 솔밭로 1 지하 1층", instagramURL: "https://instagram.com/dann.oao")
+    private var studioHeaderView: HeaderView?
     
     private let tabCellID = "tab"
     
@@ -123,7 +125,8 @@ class StudioViewController: BaseViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         scrollView.contentSize = CGSize(width: Device.width, height: contentView.frame.height)
-        isHeart = isAlreadySubscribed()
+        remoteHeartState = isAlreadySubscribed()
+        isHeart = remoteHeartState
     }
     //MARK: - Selectors
     
@@ -195,11 +198,12 @@ class StudioViewController: BaseViewController {
         heartView.isUserInteractionEnabled = true
         
         // studioHeaderView
-        contentView.addSubview(studioHeaderView)
-        studioHeaderView.translatesAutoresizingMaskIntoConstraints = false
-        studioHeaderView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-        studioHeaderView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
-        studioHeaderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+        studioHeaderView = HeaderView(frame: .zero, coverImageURL: nil, profileImageURL: nil, title: "\(studio?.name ?? "") STUDIO", subtitle: studio?.description, instagramURL: "https://instagram.com/dann.oao")
+        contentView.addSubview(studioHeaderView!)
+        studioHeaderView!.translatesAutoresizingMaskIntoConstraints = false
+        studioHeaderView!.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        studioHeaderView!.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        studioHeaderView!.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
         
         // tabCollectionView
         tabCollectionView.register(TabCell.self, forCellWithReuseIdentifier: tabCellID)
@@ -208,7 +212,7 @@ class StudioViewController: BaseViewController {
         
         contentView.addSubview(tabCollectionView)
         tabCollectionView.translatesAutoresizingMaskIntoConstraints = false
-        tabCollectionView.topAnchor.constraint(equalTo: studioHeaderView.bottomAnchor).isActive = true
+        tabCollectionView.topAnchor.constraint(equalTo: studioHeaderView!.bottomAnchor).isActive = true
         tabCollectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
         tabCollectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
         tabCollectionView.heightAnchor.constraint(equalToConstant: 48).isActive = true
@@ -267,7 +271,7 @@ class StudioViewController: BaseViewController {
     
     func isAlreadySubscribed() -> Bool {
         if let subscriptions = UserDefaults.standard.stringArray(forKey: "SubscribedStudios") {
-            if subscriptions.contains(studioID) {
+            if subscriptions.contains(studio!.id) {
                 return true
             }
             return false
@@ -283,11 +287,11 @@ class StudioViewController: BaseViewController {
             if(subscriptions.count > 10) {
                 subscriptions.removeFirst()
             }
-            subscriptions.append(studioID)
+            subscriptions.append(studio!.id)
             UserDefaults.standard.set(subscriptions, forKey: "SubscribedStudios")
         } else {
             var newList = [String]()
-            newList.append(studioID)
+            newList.append(studio!.id)
             UserDefaults.standard.set(newList, forKey: "SubscribedStudios")
         }
     }
@@ -295,7 +299,7 @@ class StudioViewController: BaseViewController {
     func removeFromSubscription() {
         if !isAlreadySubscribed() { return }
         
-        let subscriptions = UserDefaults.standard.stringArray(forKey: "SubscribedStudios")!.filter { $0 != studioID }
+        let subscriptions = UserDefaults.standard.stringArray(forKey: "SubscribedStudios")!.filter { $0 != studio!.id }
         UserDefaults.standard.set(subscriptions, forKey: "SubscribedStudios")
     }
     

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -129,6 +129,7 @@ class StudioViewController: BaseViewController {
         remoteHeartState = isAlreadySubscribed()
         isHeart = remoteHeartState
     }
+    
     //MARK: - Selectors
     
     @objc func backButtonDidTap() {
@@ -400,8 +401,8 @@ extension StudioViewController: UIScrollViewDelegate {
     }
 }
 
-
 //MARK: - Preview
+
 import SwiftUI
 
 struct StudioViewControllerRepresentable: UIViewControllerRepresentable {

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -291,8 +291,9 @@ class StudioViewController: BaseViewController {
         if isAlreadySubscribed() { return }
         
         if var subscriptions = UserDefaults.standard.stringArray(forKey: "SubscribedStudios") {
-            if(subscriptions.count > 10) {
-                subscriptions.removeFirst()
+            if(subscriptions.count >= 10) {
+                presentBottomAlert(message: "구독 가능한 스튜디오는 최대 10개입니다.")
+                return
             }
             subscriptions.append(studio!.id)
             UserDefaults.standard.set(subscriptions, forKey: "SubscribedStudios")

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -135,8 +135,10 @@ class StudioViewController: BaseViewController {
         if remoteHeartState != isHeart {
             if isHeart {
                 addToSubscription()
+                StudioManager.shared.incrementLikes(studioName: studio?.name ?? "")
             } else {
                 removeFromSubscription()
+                StudioManager.shared.decrementLikes(studioName: studio?.name ?? "")
             }
         }
     }

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -13,7 +13,8 @@ class StudioViewController: BaseViewController {
     
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        
+        scrollView.contentInset = UIEdgeInsets(top: -(UIApplication.shared.currentUIWindow()?.safeAreaInsets.top ?? 0), left: 0, bottom: 0, right: 0)
+  
         return scrollView
     }()
     
@@ -25,12 +26,54 @@ class StudioViewController: BaseViewController {
     
     private var studioHeaderView = HeaderView(frame: .zero, coverImageURL: nil, profileImageURL: nil, title: "HIGGS STUDIO", subtitle: "서울특별시 관악구 솔밭로 1 지하 1층", instagramURL: "https://instagram.com/dann.oao")
     
+    private let tabCellID = "tab"
+    
+    private let tabString = ["소개", "클래스", "이벤트"]
+    
+    private let tabCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        layout.scrollDirection = .horizontal
+        layout.minimumInteritemSpacing = 0
+        layout.minimumLineSpacing = 0
+        cv.backgroundColor = .background
+        cv.showsHorizontalScrollIndicator = false
+        
+        return cv
+    }()
+    
+    private var selectedTab = 0
+    
+    private let tabIndicatorView: UIView = UIView()
+    
+    private var tabIndicator: Separator = {
+        let sep = Separator()
+        sep.backgroundColor = .white
+        return sep
+    }()
+    
+    private let sampleContentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBlue
+        
+        return view
+    }()
+    
     //MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        self.scrollView.contentInsetAdjustmentBehavior = .never;
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     //MARK: - Selectors
@@ -65,9 +108,80 @@ class StudioViewController: BaseViewController {
         studioHeaderView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
         studioHeaderView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
         studioHeaderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+        
+        // tabCollectionView
+        tabCollectionView.register(TabCell.self, forCellWithReuseIdentifier: tabCellID)
+        tabCollectionView.dataSource = self
+        tabCollectionView.delegate = self
+        
+        contentView.addSubview(tabCollectionView)
+        tabCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        tabCollectionView.topAnchor.constraint(equalTo: studioHeaderView.bottomAnchor).isActive = true
+        tabCollectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        tabCollectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+        tabCollectionView.heightAnchor.constraint(equalToConstant: 48).isActive = true
 
+        // tabIndicatorView
+        contentView.addSubview(tabIndicatorView)
+        tabIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        tabIndicatorView.topAnchor.constraint(equalTo: tabCollectionView.bottomAnchor).isActive = true
+        tabIndicatorView.leadingAnchor.constraint(equalTo: tabCollectionView.leadingAnchor).isActive = true
+        tabIndicatorView.trailingAnchor.constraint(equalTo: tabCollectionView.trailingAnchor).isActive = true
+        tabIndicatorView.heightAnchor.constraint(equalToConstant: 3).isActive = true
+        
+        // Add tabIndicator to tabIndicatorView
+        tabIndicatorView.addSubview(tabIndicator)
+        tabIndicator.translatesAutoresizingMaskIntoConstraints = false
+        tabIndicator.topAnchor.constraint(equalTo: tabIndicatorView.topAnchor).isActive = true
+        tabIndicator.leadingAnchor.constraint(equalTo: tabIndicatorView.leadingAnchor).isActive = true
+        tabIndicator.bottomAnchor.constraint(equalTo: tabIndicatorView.bottomAnchor).isActive = true
+        tabIndicator.widthAnchor.constraint(equalToConstant: Device.width / CGFloat(tabString.count)).isActive = true
+        
+//        // test
+//        contentView.addSubview(sampleContentView)
+//        sampleContentView.translatesAutoresizingMaskIntoConstraints = false
+//        sampleContentView.topAnchor.constraint(equalTo: tabCollectionView.bottomAnchor).isActive = true
+//        sampleContentView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+//        sampleContentView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+//        sampleContentView.heightAnchor.constraint(equalToConstant: 1000).isActive = true
     }
     
+}
+
+// MARK: - UICollectionView Extension
+
+extension StudioViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: tabCellID, for: indexPath) as! TabCell
+        cell.tabNameLabel.text = tabString[indexPath.item]
+        if selectedTab == indexPath.item {
+            cell.tabNameLabel.textColor = .white
+        } else {
+            cell.tabNameLabel.textColor = .gray
+        }
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return tabString.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        UIView.animate(withDuration: 0.3) {
+            self.tabIndicator.frame.origin.x = CGFloat(indexPath.item) * (Device.width / CGFloat(self.tabString.count))
+        }
+        selectedTab = indexPath.item
+        collectionView.reloadData()
+    }
+}
+
+extension StudioViewController: UICollectionViewDelegate {
+}
+
+extension StudioViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width / CGFloat(tabString.count), height: collectionView.frame.height)
+    }
 }
 
 //MARK: - Preview

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -27,6 +27,7 @@ class StudioViewController: BaseViewController {
     private let navigationBar: UIView = {
         let view = UIView()
         view.backgroundColor = .clear
+        view.alpha = 0.7
         
         return view
     }()

--- a/Hypeclass/Source/Studio/TabCell.swift
+++ b/Hypeclass/Source/Studio/TabCell.swift
@@ -1,0 +1,42 @@
+//
+//  TabCell.swift
+//  Hypeclass
+//
+//  Created by Jiyoung Park on 2022/07/30.
+//
+
+import UIKit
+
+class TabCell: UICollectionViewCell {
+    
+    //MARK: - Properties
+    
+    let tabNameLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .gray
+        label.font = .systemFont(ofSize: 20, weight: .semibold)
+        
+        return label
+    }()
+    
+    //MARK: - LifeCycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - Helpers
+    
+    private func configureLayout() {
+        // tabNameLabel
+        contentView.addSubview(tabNameLabel)
+        tabNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        tabNameLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
+        tabNameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+    }
+}

--- a/Hypeclass/Source/Subscription/SubscriptionViewController.swift
+++ b/Hypeclass/Source/Subscription/SubscriptionViewController.swift
@@ -43,7 +43,6 @@ class SubscriptionViewController: BaseViewController{
         return sep
     }()
     
-//    private var isDancerTab = true
     private var selectedTab = 0
     
     private let cellID = "subscription"

--- a/Hypeclass/Source/Subscription/SubscriptionViewController.swift
+++ b/Hypeclass/Source/Subscription/SubscriptionViewController.swift
@@ -50,18 +50,22 @@ class SubscriptionViewController: BaseViewController{
     
     private var dancerIDs = UserDefaults.standard.stringArray(forKey: "SubscribedDancers") ?? ["958DDBD8-689E-49D0-AC60-F7C0EC2611BC", "ADC4A0E1-50DF-4784-9228-EE4622C226E8", "0E36AA46-941C-40B0-9B18-818745EE1FD0"]
     
-    private var studioIDs = UserDefaults.standard.stringArray(forKey: "SubscribedStudios") ?? ["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"]
+//    private var studioIDs = UserDefaults.standard.stringArray(forKey: "SubscribedStudios") ?? ["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"]
+    private var studioIDs = ["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"]
     
     // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        UserDefaults.standard.set(["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"], forKey: "SubscribedStudios")
         configureUI()
         configureTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        studioIDs = UserDefaults.standard.stringArray(forKey: "SubscribedStudios") ?? []
+        tableView.reloadData()
         Task {
             await requestMyDancers()
             await requestMyStudios()
@@ -145,6 +149,7 @@ class SubscriptionViewController: BaseViewController{
     
     // DancerManager.myDancers가 nil이면 Userdefault에 저장된 구독한 댄서 아이디 배열로 firebase에서 댄서 정보를 가져옵니다.
     private func requestMyDancers() async {
+        if dancerIDs.count <= 0 { return }
         do {
             if DancerManager.myDancers == nil {
                 IndicatorView.shared.show()
@@ -161,6 +166,7 @@ class SubscriptionViewController: BaseViewController{
     
     // StudioManager.myStudios가 nil이면 Userdefault에 저장된 구독한 스튜디오 아이디 배열로 firebase에서 스튜디오 정보를 가져옵니다.
     private func requestMyStudios() async {
+        if studioIDs.count <= 0 { return }
         do {
             if StudioManager.myStudios == nil {
                 IndicatorView.shared.show()
@@ -211,6 +217,7 @@ extension SubscriptionViewController: UITableViewDelegate, UITableViewDataSource
             //cell.profileImage.load(url: URL(string: "https://src.hidoc.co.kr/image/lib/2021/4/28/1619598179113_0.jpg")!)
             cell.profileImage.image = UIImage()
             cell.backgroundColor = .clear
+            cell.accessibilityLabel = StudioManager.myStudios?[indexPath.row].id
             
             return cell
         default:
@@ -225,10 +232,11 @@ extension SubscriptionViewController: UITableViewDelegate, UITableViewDataSource
             dancerDetailVC.dancerID = DancerManager.myDancers?[indexPath.row].id
             self.navigationController?.pushViewController(dancerDetailVC, animated: true)
         case 1:
-            // TODO: 스튜디오 디테일 페이지로 이동, 스튜디오 ID 넘기기
-            print("Move to studio detail")
+            let studioDetailVC = StudioViewController()
+            studioDetailVC.studio = StudioManager.myStudios?[indexPath.row]
+            self.navigationController?.pushViewController(studioDetailVC, animated: true)
         default:
-            print("default")
+            return
         }
     }
     
@@ -241,12 +249,13 @@ extension SubscriptionViewController: UITableViewDelegate, UITableViewDataSource
                 // TODO: UserDefault에 변경사항 반영
                 tableView.deleteRows(at: [indexPath], with: .fade)
             case 1:
+                let subscriptions = UserDefaults.standard.stringArray(forKey: "SubscribedStudios")!.filter { $0 != StudioManager.myStudios?[indexPath.row].id }
+                UserDefaults.standard.set(subscriptions, forKey: "SubscribedStudios")
                 StudioManager.myStudios?.remove(at: indexPath.row)
                 studioIDs.remove(at: indexPath.row)
-                // TODO: UserDefault에 변경사항 반영
                 tableView.deleteRows(at: [indexPath], with: .fade)
             default:
-                print("default")
+                return
             }
         }
     }

--- a/Hypeclass/Util/ReusableComponent/HeaderView.swift
+++ b/Hypeclass/Util/ReusableComponent/HeaderView.swift
@@ -13,14 +13,14 @@ class HeaderView: UIView {
     
     private let coverImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "DancerCoverImage")
+        imageView.backgroundColor = .gray
         
         return imageView
     }()
     
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "DancerProfileImage")
+        imageView.backgroundColor = .gray
         imageView.layer.cornerRadius = 10
         imageView.clipsToBounds = true
         

--- a/Hypeclass/Util/ReusableComponent/HeaderView.swift
+++ b/Hypeclass/Util/ReusableComponent/HeaderView.swift
@@ -31,6 +31,7 @@ class HeaderView: UIView {
         let label = UILabel()
         label.textColor = .white
         label.font = .systemFont(ofSize: 16.0, weight: .medium)
+        
         return label
     }()
     
@@ -38,6 +39,8 @@ class HeaderView: UIView {
         let label = UILabel()
         label.textColor = .white
         label.font = .systemFont(ofSize: 12.0, weight: .ultraLight)
+        label.numberOfLines = 2
+        
         return label
     }()
     
@@ -103,12 +106,14 @@ class HeaderView: UIView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.topAnchor.constraint(equalTo: profileImageView.topAnchor, constant: 10).isActive = true
         titleLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 20).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -25).isActive = true
         
         // subtitleLabel
         self.addSubview(subtitleLabel)
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 1).isActive = true
         subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
+        subtitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor).isActive = true
         
         // instagramImageView
         self.addSubview(instagramImageView)

--- a/Hypeclass/Util/ReusableComponent/HeaderView.swift
+++ b/Hypeclass/Util/ReusableComponent/HeaderView.swift
@@ -1,0 +1,124 @@
+//
+//  HeaderView.swift
+//  Hypeclass
+//
+//  Created by Jiyoung Park on 2022/07/30.
+//
+
+import UIKit
+
+class HeaderView: UIView {
+    
+    // MARK: - Properties
+    
+    private let coverImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "DancerCoverImage")
+        
+        return imageView
+    }()
+    
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "DancerProfileImage")
+        imageView.layer.cornerRadius = 10
+        imageView.clipsToBounds = true
+        
+        return imageView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16.0, weight: .medium)
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 12.0, weight: .ultraLight)
+        return label
+    }()
+    
+    private let instagramImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "DancerInstagramImage")
+        imageView.contentMode = .scaleAspectFit
+        
+        return imageView
+    }()
+    
+    private var instagramURL: String?
+    
+    // MARK: - LifeCycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+    }
+    
+    required init(frame: CGRect, coverImageURL: String?, profileImageURL: String?, title: String?, subtitle: String?, instagramURL: String?) {
+        super.init(frame: .zero)
+        
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+        self.instagramURL = instagramURL
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Selectors
+    
+    @objc func instaImageTapped() {
+        if let url = URL(string: self.instagramURL ?? "https://instagram.com/wootae_______?igshid=YmMyMTA2M2Y=") {
+            UIApplication.shared.open(url, options: [:])
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func configureUI() {
+        // coverImageView
+        self.addSubview(coverImageView)
+        coverImageView.translatesAutoresizingMaskIntoConstraints = false
+        coverImageView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+        coverImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+        coverImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+        coverImageView.heightAnchor.constraint(equalToConstant: 220).isActive = true
+        
+        // profileImageView
+        self.addSubview(profileImageView)
+        profileImageView.translatesAutoresizingMaskIntoConstraints = false
+        profileImageView.topAnchor.constraint(equalTo: coverImageView.bottomAnchor, constant: 20).isActive = true
+        profileImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 25).isActive = true
+        profileImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -20).isActive = true
+        profileImageView.heightAnchor.constraint(equalToConstant: 90).isActive = true
+        profileImageView.widthAnchor.constraint(equalToConstant: 90).isActive = true
+        
+        // titleLabel
+        self.addSubview(titleLabel)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.topAnchor.constraint(equalTo: profileImageView.topAnchor, constant: 10).isActive = true
+        titleLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 20).isActive = true
+        
+        // subtitleLabel
+        self.addSubview(subtitleLabel)
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 1).isActive = true
+        subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
+        
+        // instagramImageView
+        self.addSubview(instagramImageView)
+        instagramImageView.translatesAutoresizingMaskIntoConstraints = false
+        instagramImageView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
+        instagramImageView.bottomAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: -10).isActive = true
+        instagramImageView.heightAnchor.constraint(equalToConstant: 22).isActive = true
+        instagramImageView.widthAnchor.constraint(equalToConstant: 22).isActive = true
+        
+        instagramImageView.isUserInteractionEnabled = true
+        instagramImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(instaImageTapped)))
+    }
+}

--- a/Hypeclass/Util/ReusableComponent/ItemCell.swift
+++ b/Hypeclass/Util/ReusableComponent/ItemCell.swift
@@ -82,28 +82,6 @@ class ItemCell: UITableViewCell {
         profileImage.heightAnchor.constraint(equalToConstant: 65).isActive = true
         profileImage.backgroundColor = .gray
         
-        // Add titleLabel, subtitleLabel, detailLable to textView
-        textView.addSubview(titleLabel)
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor).isActive = true
-        titleLabel.topAnchor.constraint(equalTo: textView.topAnchor).isActive = true
-        
-        textView.addSubview(subtitleLabel)
-        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
-        subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 7).isActive = true
-        
-        textView.addSubview(detailLabel)
-        detailLabel.translatesAutoresizingMaskIntoConstraints = false
-        detailLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
-        detailLabel.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 2).isActive = true
-        
-        // textView
-        self.addSubview(textView)
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.leadingAnchor.constraint(equalTo: profileImage.trailingAnchor, constant: 20).isActive = true
-        textView.topAnchor.constraint(equalTo: self.topAnchor, constant: 30).isActive = true
-
         // >
         self.addSubview(navigationImage)
         navigationImage.translatesAutoresizingMaskIntoConstraints = false
@@ -111,6 +89,32 @@ class ItemCell: UITableViewCell {
         navigationImage.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24).isActive = true
         navigationImage.widthAnchor.constraint(equalToConstant: 9).isActive = true
         navigationImage.heightAnchor.constraint(equalToConstant: 19).isActive = true
+        
+        // textView
+        self.addSubview(textView)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.leadingAnchor.constraint(equalTo: profileImage.trailingAnchor, constant: 20).isActive = true
+        textView.topAnchor.constraint(equalTo: self.topAnchor, constant: 30).isActive = true
+        textView.trailingAnchor.constraint(equalTo: navigationImage.trailingAnchor, constant: -20).isActive = true
+        
+        // Add titleLabel, subtitleLabel, detailLable to textView
+        textView.addSubview(titleLabel)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor).isActive = true
+        titleLabel.topAnchor.constraint(equalTo: textView.topAnchor).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: textView.trailingAnchor).isActive = true
+        
+        textView.addSubview(subtitleLabel)
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
+        subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 7).isActive = true
+        subtitleLabel.trailingAnchor.constraint(equalTo: textView.trailingAnchor).isActive = true
+        
+        textView.addSubview(detailLabel)
+        detailLabel.translatesAutoresizingMaskIntoConstraints = false
+        detailLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
+        detailLabel.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 2).isActive = true
+        detailLabel.trailingAnchor.constraint(equalTo: textView.trailingAnchor).isActive = true
     }
 }
 


### PR DESCRIPTION
## 개요
- #116 
- StudioViewController 구현

## 작업내용
#### Util/ReusableComponent에 재사용 가능한 HeaderView를 추가했습니다.
- 인스타그램 로고를 누르면 해당 인스타그램 URL 주소로 이동합니다.
#### StudioViewController를 추가했습니다.
- 커스텀 네비게이션 바를 구현했습니다.
- 스크롤이 내려가면 네비게이션 바의 배경색이 생기고 최상단으로 올라오면 다시 투명해집니다.
- 커스텀 탭 바 구현했습니다.
- 페이지 뷰 컨트롤러 구현했습니다. 스와이프/탭 버튼 터치 모두 작동합니다.
- Userdefault 저장 및 삭제 구현했습니다. (최대 10개, 10개일 때 구독을 시도하면 토스트 메시지를 띄웁니다.)
- 파이어베이스 likes increment/decrement 구현했습니다.
- Studio 모델에 likes: Int? 프로퍼티 추가했습니다.
- 하트를 누르면 구독/구독 취소 토스트 메시지를 띄웁니다.
#### SubscriptionViewController의 스튜디오 탭과 StudioViewController를 연결했습니다.
- 스튜디오 탭에서 스와이프를 통한 삭제가 데이터에 반영됩니다.
- StudioViewController에서 구독 취소가 일어나면 SubscriptionViewController에 반영됩니다.

## 고민사항
- 페이지 뷰 컨트롤러의 하위 페이지 연결이 필요합니다.
- 이미지 url 작업이 필요합니다.
- 헤더 뷰의 label 텍스트 길이 논의가 필요합니다. (글자수 제한)
<img width="322" alt="image" src="https://user-images.githubusercontent.com/59128435/182035652-06c669d8-cea5-44b5-9711-ada15148abfa.png">


## 이미지(UI 관련작업시)

https://user-images.githubusercontent.com/59128435/181937379-828a98a2-916a-41f6-b047-baa6b29c9df2.mp4


