### PR TITLE
[FEAT] 댄스 클래스 뷰 네트워크 연동 , 데이터 전처리

### DIFF
--- a/Hypeclass/API/StudioManager.swift
+++ b/Hypeclass/API/StudioManager.swift
@@ -16,7 +16,7 @@ class StudioManager {
     static var allStudios: [Studio]?
     
     func createStudio(id: String, name: String, dancers: [String]) {
-        let studio = Studio(id: id, name: name, description: "\(name) description", instagramURL: nil, youtubeURL: nil, dancers: dancers, likes: nil)
+        let studio = Studio(id: id, name: name, description: "\(name) description", profileImageURL: nil , coverImageURL: nil , instagramURL: nil, youtubeURL: nil, dancers: dancers, likes: nil)
         do {
             try Constant.studioRef.document("\(name)").setData(from: studio)
         } catch let error {

--- a/Hypeclass/Model/MockDataSet.swift
+++ b/Hypeclass/Model/MockDataSet.swift
@@ -45,4 +45,19 @@ class MockDataSet {
         }
         return []
     }()
+    
+    static let danceClass: DanceClass = DanceClass(id: "83349D56-0B2A-4488-BD34-66C64854DC50", name: "아프로 스타일 하우스 클래스", genres: nil, description: """
+        춤추고 싶은 사람 누구나 참여 가능한
+        힉스 비디오 클래스!
+        
+        *다채로운 영상을 남기고 싶은 각양각색의
+        댄서나 일반인을 모집합니다.
+        
+        - 진행기간 :
+        8월 1일 첫째주 부터 9월 9일까지 (6주간)
+        
+        - 정원 : 각 레슨마다 10명씩
+        
+        - 촬영 날짜: 9월 18일 일요일 오후 12시 이후
+        """, isPopUp: false, startTime: Date(), endTime: Date() + (2 * 60 * 60), dancerID: "958DDBD8-689E-49D0-AC60-F7C0EC2611BC", dancerName: "Luke", studioID: "D643807C-DC29-482B-B2BD-0E9B5189E428", studioName: "HIGGS Studio")
 }

--- a/Hypeclass/Model/Studio.swift
+++ b/Hypeclass/Model/Studio.swift
@@ -11,6 +11,8 @@ struct Studio: Codable {
     let id: String
     let name: String?
     let description: String?
+    let profileImageURL: String?
+    let coverImageURL: String?
     let instagramURL: String?
     let youtubeURL: String?
     let dancers: [String]?

--- a/Hypeclass/Source/DanceClassDetailViewController.swift
+++ b/Hypeclass/Source/DanceClassDetailViewController.swift
@@ -33,6 +33,7 @@ class DanceClassDetailViewController: BaseViewController {
     private let coverImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .gray
+        imageView.contentMode = .scaleToFill
         
         return imageView
     }()

--- a/Hypeclass/Source/DanceClassDetailViewController.swift
+++ b/Hypeclass/Source/DanceClassDetailViewController.swift
@@ -99,7 +99,6 @@ class DanceClassDetailViewController: BaseViewController {
         configureUI()
         configureTableView()
         scrollView.delegate = self
-//        configure()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -124,12 +123,6 @@ class DanceClassDetailViewController: BaseViewController {
     
     //MARK: - Helpers
     
-    func configureTableView() {
-        tableView.register(ItemCell.self, forCellReuseIdentifier: "DanceClassDetailCell")
-        tableView.delegate = self
-        tableView.dataSource = self
-    }
-    
     func configure() {
         guard let model = model else { return }
         guard let dancerID = model.dancerID else { return }
@@ -137,6 +130,7 @@ class DanceClassDetailViewController: BaseViewController {
         IndicatorView.shared.show()
         IndicatorView.shared.showIndicator()
         titleLabel.text = model.name
+        secondaryLabel.text = "\(model.startTime?.text ?? "") \(model.startTime?.dayOfTheWeek ?? "") \(model.startTime?.hourMinText ?? "") ~ \(model.endTime?.hourMinText ?? "")"
         aboutTextView.text = model.description
 
         Task {
@@ -156,6 +150,12 @@ class DanceClassDetailViewController: BaseViewController {
                 presentBottomAlert(message: "데이터를 불러오지 못했습니다.")
             }
         }
+    }
+    
+    func configureTableView() {
+        tableView.register(ItemCell.self, forCellReuseIdentifier: "DanceClassDetailCell")
+        tableView.delegate = self
+        tableView.dataSource = self
     }
     
     func configureUI() {

--- a/Hypeclass/Util/Extension/Date.swift
+++ b/Hypeclass/Util/Extension/Date.swift
@@ -16,13 +16,26 @@ extension Date {
     
     var text: String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.dateFormat = "MM월 dd일"
         return dateFormatter.string(from: self)
     }
     
     var detailText: String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
+        dateFormatter.dateFormat = "yyyy-MM-dd hh:mm"
+        return dateFormatter.string(from: self)
+    }
+    
+    var hourMinText: String { // 시 분 만 출력
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm"
+        return dateFormatter.string(from: self)
+    }
+    
+    var dayOfTheWeek: String { // 한국말 요일 리턴
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko") // 한국 지정
+        dateFormatter.dateFormat = "E요일"
         return dateFormatter.string(from: self)
     }
     
@@ -39,7 +52,6 @@ extension Date {
         return formatter.localizedString(for: self, relativeTo: Date())
     }
     
-    //2022-01-11T08:18:09.000Z 에 해당하는 메서드 만들기
     
     // 캘린더의 컴포넌트를 가져오는 extension(eg. Date().get(.month) -> 오늘 날짜에 해당하는 월 반환)
     func get(_ components: Calendar.Component..., calendar: Calendar = Calendar.current) -> DateComponents {


### PR DESCRIPTION
## 개요
- 관련이슈 번호를 적어주세요.
- 댄스클래스뷰 네트워크 연동

## 작업내용
- 댄스클래스 데이터 내부의 스튜디오 ID 와 댄서 ID 를 사용해서 해당 클래스의 강사와 스튜디오를 불러옵니다.
  - 테이블 뷰로 구현해 강사가 2명 이상인 경우에도 대비했습니다.
- Date 익스텐션 메서드 구현 및 수정
  - 요일을 가져오는 계산 프로퍼티 추가
  - '11월 22일'  와 같이 날짜를 리턴하는 계산프로퍼티 구현
- Studio 모델에 커버이미지 URL , 프로필 이미지 URL 프로퍼티 추가

## 고민사항
- View 간 연결 작업만 수행하면 됩니다.

## 이미지(UI 관련작업시)

https://user-images.githubusercontent.com/89325126/182186991-12647d8c-ba79-4723-80bb-a63f9f40520f.mp4


