### PR TITLE
[FEAT] 스튜디오 디테일 뷰 스케줄 탭 연결

### DIFF
--- a/Hypeclass.xcodeproj/project.pbxproj
+++ b/Hypeclass.xcodeproj/project.pbxproj
@@ -79,7 +79,7 @@
 		C76C91D228951E3900703CCD /* TabCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91D128951E3800703CCD /* TabCell.swift */; };
 		C76C91D62896EE1900703CCD /* ScheduleItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91D52896EE1900703CCD /* ScheduleItemView.swift */; };
 		C76C91D828970BA800703CCD /* ScheduleItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91D728970BA800703CCD /* ScheduleItemCell.swift */; };
-		C76C91CA2893C0BE00703CCD /* MainStudioCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91C92893C0BE00703CCD /* MainStudioCell.swift */; };
+		C76C91DE289910D000703CCD /* StudioScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76C91DD289910D000703CCD /* StudioScheduleViewController.swift */; };
 		C7CE676028807C8E00C8F137 /* WeekdayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */; };
 		C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE676128814D3C00C8F137 /* Weekday.swift */; };
 		C7CE67AF2886F70700C8F137 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CE67AE2886F70700C8F137 /* ScheduleView.swift */; };
@@ -159,7 +159,7 @@
 		C76C91D128951E3800703CCD /* TabCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCell.swift; sourceTree = "<group>"; };
 		C76C91D52896EE1900703CCD /* ScheduleItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleItemView.swift; sourceTree = "<group>"; };
 		C76C91D728970BA800703CCD /* ScheduleItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleItemCell.swift; sourceTree = "<group>"; };
-		C76C91C92893C0BE00703CCD /* MainStudioCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainStudioCell.swift; sourceTree = "<group>"; };
+		C76C91DD289910D000703CCD /* StudioScheduleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudioScheduleViewController.swift; sourceTree = "<group>"; };
 		C7CE675F28807C8E00C8F137 /* WeekdayCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdayCell.swift; sourceTree = "<group>"; };
 		C7CE676128814D3C00C8F137 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		C7CE67AE2886F70700C8F137 /* ScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
@@ -404,9 +404,9 @@
 			children = (
 				C76C91CD2894509600703CCD /* StudioViewController.swift */,
 				C0FD9C2D2898B9AB00D33C72 /* StudioEventViewController.swift */,
-				C76C91D128951E3800703CCD /* TabCell.swift */,
 				C0FD9C2F2898BB9B00D33C72 /* StudioEventCell.swift */,
 				C76C91D128951E3800703CCD /* TabCell.swift */,
+				C76C91DD289910D000703CCD /* StudioScheduleViewController.swift */,
 			);
 			path = Studio;
 			sourceTree = "<group>";
@@ -547,6 +547,7 @@
 				C05BF1F8287BC7EF00C95E1B /* UIImage.swift in Sources */,
 				C7CE676228814D3C00C8F137 /* Weekday.swift in Sources */,
 				C76C91D02894559600703CCD /* HeaderView.swift in Sources */,
+				C76C91DE289910D000703CCD /* StudioScheduleViewController.swift in Sources */,
 				C0C444FE28944DE200036ADE /* ContainerTextField.swift in Sources */,
 				C7CE67D5288FD2F900C8F137 /* DanceClassManager.swift in Sources */,
 				C0C44504289529F700036ADE /* DanceClassDetailViewController.swift in Sources */,

--- a/Hypeclass/Source/Studio/StudioScheduleViewController.swift
+++ b/Hypeclass/Source/Studio/StudioScheduleViewController.swift
@@ -1,0 +1,60 @@
+//
+//  StudioScheduleViewController.swift
+//  Hypeclass
+//
+//  Created by Jiyoung Park on 2022/08/02.
+//
+
+import UIKit
+
+class StudioScheduleViewController: BaseViewController {
+    
+    // MARK: - Properties
+    
+    var scheduleView: ScheduleItemView?
+    
+    var studioID: String?
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    
+    // MARK: - Helpers
+    
+    private func configureUI() {
+        if studioID != nil {
+            // scheduleView
+            scheduleView = ScheduleItemView(frame: .zero, studioID: self.studioID!, date: Date())
+            view.addSubview(scheduleView!)
+            scheduleView?.translatesAutoresizingMaskIntoConstraints = false
+            scheduleView?.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            scheduleView?.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 26).isActive = true
+            scheduleView?.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -26).isActive = true
+        }
+    }
+}
+
+// MARK: - Preview
+
+import SwiftUI
+
+struct StudioScheduleViewControllerRepresentable: UIViewControllerRepresentable {
+    typealias UIViewControllerType = StudioScheduleViewController
+
+    func makeUIViewController(context: Context) -> StudioScheduleViewController {
+        return StudioScheduleViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: StudioScheduleViewController, context: Context) {
+    }
+}
+
+@available(iOS 13.0.0, *)
+struct StudioScheduleViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        StudioScheduleViewControllerRepresentable()
+    }
+}

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -94,6 +94,7 @@ class StudioViewController: BaseViewController {
     
     private let pageViewController: UIPageViewController = {
         let pageController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        // MARK: - Disable swipe gesture
 
         return pageController
     }()
@@ -266,17 +267,24 @@ class StudioViewController: BaseViewController {
     
     func configurePageViewController() {
         // TO DO: 실제 뷰 컨트롤러로 대체
-        for idx in 0..<2 {
-            let vc = DancerDetailViewController()
-            vc.dancerDetailScrollView.isScrollEnabled = false
-            vc.view.tag = idx
-            pageViewController.view.heightAnchor.constraint(equalToConstant: vc.view.frame.height).isActive = true
-            viewControllers.append(vc)
-        }
+        let infoVC = DancerDetailViewController()
+        infoVC.dancerDetailScrollView.isScrollEnabled = false
+        infoVC.view.tag = 0
+        pageViewController.view.heightAnchor.constraint(equalToConstant: infoVC.view.frame.height).isActive = true
+        viewControllers.append(infoVC)
+        
+        let scheduleVC = StudioScheduleViewController()
+        scheduleVC.studioID = studio?.id
+        scheduleVC.view.tag = 1
+        scheduleVC.scheduleView?.delegate = self
+        pageViewController.view.heightAnchor.constraint(equalToConstant: scheduleVC.view.frame.height).isActive = true
+        viewControllers.append(scheduleVC)
+        
         let vc = StudioEventViewController()
         vc.view.tag = 2
         viewControllers.append(vc)
         pageViewController.view.heightAnchor.constraint(equalToConstant: vc.view.frame.height).isActive = true
+        
         if let firstVC = viewControllers.first {
             pageViewController.setViewControllers([firstVC], direction: .forward, animated: true, completion: nil)
         }
@@ -402,6 +410,17 @@ extension StudioViewController: UIScrollViewDelegate {
         } else {
             navigationBar.backgroundColor = .clear
         }
+    }
+}
+
+// MARK: - ScheduleItemDelegate extension
+
+extension StudioViewController: ScheduleItemDelegate {
+    func scheduleDidSelect(schedule: DanceClass) {
+        let vc = DanceClassDetailViewController()
+        vc.model = schedule
+        self.navigationController?.pushViewController(vc, animated: true)
+        print(schedule)
     }
 }
 

--- a/Hypeclass/Source/Studio/StudioViewController.swift
+++ b/Hypeclass/Source/Studio/StudioViewController.swift
@@ -420,7 +420,6 @@ extension StudioViewController: ScheduleItemDelegate {
         let vc = DanceClassDetailViewController()
         vc.model = schedule
         self.navigationController?.pushViewController(vc, animated: true)
-        print(schedule)
     }
 }
 

--- a/Hypeclass/Source/Subscription/SubscriptionViewController.swift
+++ b/Hypeclass/Source/Subscription/SubscriptionViewController.swift
@@ -47,16 +47,17 @@ class SubscriptionViewController: BaseViewController{
     
     private let cellID = "subscription"
     
-    private var dancerIDs = UserDefaults.standard.stringArray(forKey: "SubscribedDancers") ?? ["958DDBD8-689E-49D0-AC60-F7C0EC2611BC", "ADC4A0E1-50DF-4784-9228-EE4622C226E8", "0E36AA46-941C-40B0-9B18-818745EE1FD0"]
+//    private var dancerIDs = UserDefaults.standard.stringArray(forKey: "SubscribedDancers") ?? []
+    private var dancerIDs = [String]()
     
 //    private var studioIDs = UserDefaults.standard.stringArray(forKey: "SubscribedStudios") ?? ["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"]
-    private var studioIDs = ["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"]
+    private var studioIDs = [String]()
     
     // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        UserDefaults.standard.set(["81DB67B8-9CAC-4AFE-B261-75BF7EE54534", "E23BD12A-ACDB-4BF6-B7C8-CFFC6BA4D1D4"], forKey: "SubscribedStudios")
+        UserDefaults.standard.set(["8bc63898-aec4-44d4-8329-4bc9b52b98cd"], forKey: "SubscribedStudios")
         configureUI()
         configureTableView()
     }

--- a/Hypeclass/Util/ReusableComponent/ScheduleItemView.swift
+++ b/Hypeclass/Util/ReusableComponent/ScheduleItemView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ScheduleItemDelegate {
-    func scheduleDidSelect(scheduleID: String)
+    func scheduleDidSelect(schedule: DanceClass)
 }
 
 class ScheduleItemView: UIView {
@@ -198,7 +198,7 @@ extension ScheduleItemView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.item != 0 {
             let schedule = weekSchedules[indexPath.section][indexPath.item - 1]
-            delegate?.scheduleDidSelect(scheduleID: schedule.id)
+            delegate?.scheduleDidSelect(schedule: schedule)
         }
     }
 }


### PR DESCRIPTION
## 개요
- #149 
- 스튜디오 디테일 뷰 스케줄 탭 연결

## 작업내용
- 스튜디오 디테일 뷰에서 스케줄 탭에 StudioScheduleViewController를 연결했습니다.
- 각각의 스케줄 셀을 누르면 해당 스케줄의 디테일 뷰로 이동합니다.

## 고민사항
- 소개 탭 뷰컨트롤러 통합 작업이 필요합니다.

## 이미지(UI 관련작업시)

https://user-images.githubusercontent.com/59128435/182361923-2221d2dc-46e3-4560-a233-228548714767.mp4


